### PR TITLE
Option for benchmarking with user defined data

### DIFF
--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -74,7 +74,7 @@ These options are to be used on the command line. E.g., 'IOR -a POSIX -b 4K'.
   -J N  setAlignment -- HDF5 alignment in bytes (e.g.: 8, 4k, 2m, 1g)
   -k    keepFile -- don't remove the test file(s) on program exit
   -K    keepFileWithError  -- keep error-filled file(s) after data-checking
-  -l    data packet type-- type of packet that will be created [offset|incompressible|timestamp|o|i|t]
+  -l    data packet type-- type of packet that will be created [offset|incompressible|timestamp|userdata|o|i|t|u]
   -m    multiFile -- use number of reps (-i) for multiple file count
   -M N  memoryPerNode -- hog memory on the node (e.g.: 2g, 75%)
   -n    noFill -- no fill in HDF5 file creation
@@ -280,6 +280,9 @@ GENERAL:
   * summaryAlways        - Always print the long summary for each test.
                            Useful for long runs that may be interrupted, preventing
                            the final long summary for ALL tests to be printed.
+                           
+  * pathToInputFile      - Path to a file with user definded data, as needed for 
+  						   -l u (data packet type =  userdata)  	                   
 
 
 POSIX-ONLY:

--- a/src/ior.c
+++ b/src/ior.c
@@ -207,6 +207,7 @@ void init_IOR_Param_t(IOR_param_t * p)
         p->testComm = MPI_COMM_WORLD;
         p->setAlignment = 1;
         p->lustre_start_ost = -1;
+        strncpy(p->pathToInputFile, "\0", MAXPATHLEN);
 
         strncpy(p->hdfs_user, getenv("USER"), MAX_STR);
         p->hdfs_name_node      = "default";
@@ -868,7 +869,17 @@ FillBuffer(void *buffer,
         unsigned long long hi, lo;
         unsigned long long *buf = (unsigned long long *)buffer;
 
-        if(test->dataPacketType == incompressible ) { /* Make for some non compressable buffers with randomish data */
+        if(test->dataPacketType == userdata){ /* File buffer with user specified data from pathToFileInput */
+
+            FILE *fdUserData = fopen(test->pathToInputFile, "r");
+            if (fdUserData == NULL)
+              ERR("Couldn't open userData File");
+
+            fread(buf, test->blockSize, 1,fdUserData);
+
+            fclose(fdUserData);
+        }
+        else if(test->dataPacketType == incompressible ) { /* Make for some non compressable buffers with randomish data */
 
                 /* In order for write checks to work, we have to restart the psuedo random sequence */
                 if(reseed_incompressible_prng == TRUE) {
@@ -1356,13 +1367,23 @@ static IOR_test_t *SetupTests(int argc, char **argv)
 static void XferBuffersSetup(IOR_io_buffers* ioBuffers, IOR_param_t* test,
                              int pretendRank)
 {
-        ioBuffers->buffer = aligned_buffer_alloc(test->transferSize);
+
+	IOR_offset_t bufferSize;
+
+	if(test->dataPacketType == userdata){
+	    bufferSize = test->blockSize;
+	}
+	else{
+	    bufferSize = test->transferSize;
+	}
+
+        ioBuffers->buffer = aligned_buffer_alloc(bufferSize);
 
         if (test->checkWrite || test->checkRead) {
-                ioBuffers->checkBuffer = aligned_buffer_alloc(test->transferSize);
+                ioBuffers->checkBuffer = aligned_buffer_alloc(bufferSize);
         }
         if (test->checkRead || test->checkWrite) {
-                ioBuffers->readCheckBuffer = aligned_buffer_alloc(test->transferSize);
+                ioBuffers->readCheckBuffer = aligned_buffer_alloc(bufferSize);
         }
 
         return;
@@ -2262,7 +2283,7 @@ static void TestIoSys(IOR_test_t *test)
 
 }
 
-/*
+/**
  * Determine if valid tests from parameters.
  */
 static void ValidateTests(IOR_param_t * test)
@@ -2429,74 +2450,123 @@ static void ValidateTests(IOR_param_t * test)
         if (Nto1 && (s != 1) && (b != t)) {
                 ERR("N:1 (strided) requires xfer-size == block-size");
         }
+
+        /* Validation of filesize for userdata */
+
+        if (test->dataPacketType == userdata && test->storeFileOffset)
+                ERR("userdata and store file offset option are incompatible.");
+        if (test->dataPacketType == userdata && strlen(test->pathToInputFile) == 0)
+		ERR("Path to file for userdata is needed!");
+
+
+        //TODO Not sure if this is the right place to do do this.
+        if (test->dataPacketType == userdata )
+	{
+            // get file size of user data from pathToInputFile
+            FILE *fd;
+            fd = fopen(test->pathToInputFile, "r" );
+            fseek(fd, 0L, SEEK_END);
+            test->userdataFileSize = ftell(fd);
+            fclose(fd);
+
+            if (test->userdataFileSize < test->blockSize)
+                    ERR("userdata needs to be at least blocksize big");
+	}
+
+
 }
 
+/** \struct IOR_offsetTuple_t
+ * A pair of IOR_offset_t.
+ * One for for each, the file and memory offset.
+ */
+typedef struct {
+  IOR_offset_t memory;
+  IOR_offset_t file;
+} IOR_offsetTuple_t ;
+
+
 /**
- * Returns a precomputed array of IOR_offset_t for the inner benchmark loop.
- * They are sequential and the last element is set to -1 as end marker.
+ * Returns a precomputed array of IOR_offsetTuple_t for the inner benchmark loop.
+ * Each IOR_offsetTuple_t holdes one offset for the memory and one for the file.
+ * In both cases these offset are seqential.
  * @param test IOR_param_t for getting transferSize, blocksize and SegmentCount
  * @param pretendRank int pretended Rank for shifting the offsest corectly
- * @return IOR_offset_t
+ * @return IOR_offsetTuple_t
  */
-static IOR_offset_t *GetOffsetArraySequential(IOR_param_t * test,
+static IOR_offsetTuple_t *GetOffsetArraySequential(IOR_param_t * test,
                                               int pretendRank)
 {
-        IOR_offset_t i, j, k = 0;
-        IOR_offset_t offsets;
-        IOR_offset_t *offsetArray;
+    IOR_offset_t i, j, k = 0;
+    IOR_offset_t offsets;
+    IOR_offsetTuple_t *offsetArray;
 
-        /* count needed offsets */
-        offsets = (test->blockSize / test->transferSize) * test->segmentCount;
+    /* count needed offsets */
+    offsets = (test->blockSize / test->transferSize) * test->segmentCount;
 
-        /* setup empty array */
-        offsetArray =
-                (IOR_offset_t *) malloc((offsets + 1) * sizeof(IOR_offset_t));
-        if (offsetArray == NULL)
-                ERR("malloc() failed");
-        offsetArray[offsets] = -1;      /* set last offset with -1 */
+    /* setup empty array */
+    offsetArray  = (IOR_offsetTuple_t *)malloc(sizeof(IOR_offsetTuple_t) * (offsets + 1));
+    if (offsetArray == NULL)
+                    ERR("malloc() failed");
 
-        /* fill with offsets */
-        for (i = 0; i < test->segmentCount; i++) {
-                for (j = 0; j < (test->blockSize / test->transferSize); j++) {
-                        offsetArray[k] = j * test->transferSize;
-                        if (test->filePerProc) {
-                                offsetArray[k] += i * test->blockSize;
-                        } else {
-                                offsetArray[k] +=
-                                        (i * test->numTasks * test->blockSize)
+
+    offsetArray[offsets].file= -1;      /* set last offset with -1 */
+    offsetArray[offsets].memory = -1;   /* set last offset with -1 */
+
+
+    /* fill with offsets */
+    for (i = 0; i < test->segmentCount; i++) {
+        for (j = 0; j < (test->blockSize / test->transferSize); j++) {
+            offsetArray[k].file = j * test->transferSize;
+            if (test->filePerProc) {
+                offsetArray[k].file += i * test->blockSize;
+            } else {
+                offsetArray[k].file += (i * test->numTasks * test->blockSize)
                                         + (pretendRank * test->blockSize);
-                        }
-                        k++;
-                }
-        }
+            }
+            // save offset for buffer to read from
+            if(test->dataPacketType ==  userdata){
+                offsetArray[k].memory = j * test->transferSize;
+            } else {
+                offsetArray[k].memory = 0;
+            }
 
-        return (offsetArray);
+            k++;
+        }
+    }
+
+    return (offsetArray);
 }
 
 /**
- * Returns a precomputed array of IOR_offsett_t for the inner benchmark loop.
- * They get created sequentially and mixed up in the end. The last array element
+<<<<<<< HEAD
+
+=======
+ * Returns a precomputed array of IOR_offsettTuple_t for the inner benchmark loop.
+ * Each IOR_offsettTuple_t holdes one offset for the memory and one for the file.
+ * All IOR_offsettTuple_t get mixed up at the end. The last array element
  * is set to -1 as end marker.
  * It should be noted that as the seeds get synchronised across all processes
  * every process computes the same random order if used with filePerProc.
+>>>>>>> Option for benchmarking with user defined data
  * For a shared file all transfers get randomly assigned to ranks. The processes
  * can also have differen't numbers of transfers. This might lead to a bigger
  * diversion in accesse as it dose with filePerProc. This is expected but
  * should be mined.
  * @param test IOR_param_t for getting transferSize, blocksize and SegmentCount
  * @param pretendRank int pretended Rank for shifting the offsest corectly
- * @return IOR_offset_t
+ * @return IOR_offsetTuple_t
  * @return
  */
-static IOR_offset_t *GetOffsetArrayRandom(IOR_param_t * test, int pretendRank,
+static IOR_offsetTuple_t *GetOffsetArrayRandom(IOR_param_t * test, int pretendRank,
                                           int access)
 {
         int seed;
-        IOR_offset_t i, value, tmp;
+        IOR_offset_t i, j, k, value;
         IOR_offset_t offsets = 0;
         IOR_offset_t offsetCnt = 0;
         IOR_offset_t fileSize;
-        IOR_offset_t *offsetArray;
+        IOR_offsetTuple_t *offsetArray, tmp;
 
         /* set up seed for random() */
         if (access == WRITE || access == READ) {
@@ -2506,46 +2576,63 @@ static IOR_offset_t *GetOffsetArrayRandom(IOR_param_t * test, int pretendRank,
         }
         srandom(seed);
 
-        fileSize = test->blockSize * test->segmentCount;
-        if (test->filePerProc == FALSE) {
-                fileSize *= test->numTasks;
-        }
-
-        /* count needed offsets (pass 1) */
-        for (i = 0; i < fileSize; i += test->transferSize) {
-                if (test->filePerProc == FALSE) {
-                        // this counts which process get how many transferes in
-                        // a shared file
-                        if ((random() % test->numTasks) == pretendRank) {
-                                offsets++;
-                        }
-                } else {
-                        offsets++;
-                }
-        }
-
-        /* setup empty array */
-        offsetArray =
-                (IOR_offset_t *) malloc((offsets + 1) * sizeof(IOR_offset_t));
-        if (offsetArray == NULL)
-                ERR("malloc() failed");
-        offsetArray[offsets] = -1;      /* set last offset with -1 */
 
         if (test->filePerProc) {
-                /* fill array */
-                for (i = 0; i < offsets; i++) {
-                        offsetArray[i] = i * test->transferSize;
-                }
+            // file perProc is identical with the sequential just reordered in
+            // the end
+           offsetArray = GetOffsetArraySequential(test, pretendRank);
         } else {
-                /* fill with offsets (pass 2) */
-                srandom(seed);  /* need same seed  to get same transfers as counted in the beginning*/
-                for (i = 0; i < fileSize; i += test->transferSize) {
-                        if ((random() % test->numTasks) == pretendRank) {
-                                offsetArray[offsetCnt] = i;
-                                offsetCnt++;
+	    /* This case is different as the number of transfers dose not have
+	     * to be spread equaly above the processes.
+	     * Therefor every process might have to allocate memory for a
+	     * different number of offsets.
+	     */
+
+            // callculating file size to determine the total number of transfers
+            fileSize = test->blockSize * test->segmentCount * test->numTasks;
+
+            // count needed offsets (pass 1)
+            for (i = 0; i < fileSize; i += test->transferSize) {
+    		    if ((random() % test->numTasks) == pretendRank) {
+    			    offsets++;
+    		    }
+            }
+
+            // allocating offsets
+            offsetArray  = (IOR_offsetTuple_t *)malloc(sizeof(IOR_offsetTuple_t) * (offsets + 1));
+            if (offsetArray == NULL)
+                            ERR("malloc() failed");
+
+            // initilising last files with -1
+            offsetArray[offsets].file= -1;      /* set last offset with -1 */
+            offsetArray[offsets].memory = -1;   /* set last offset with -1 */
+
+    	    /* fill with offsets (pass 2) */
+    	    srandom(seed);  /* need same seed as in counting*/
+    	    // both loops needed for j counter in user data
+            for (i = 0; i < test->segmentCount; i++) {
+                for (k = 0; k < test->numTasks; k++) {
+                    for (j = 0; j < (test->blockSize / test->transferSize); j++) {
+                        // only add assigne transfers to GetOffsetArrayRandom
+                        // and skip the hole transfers
+                        if ( (random() % test->numTasks) == pretendRank)
+                        {
+                            offsetArray[offsetCnt].file = (i * test->numTasks * test->blockSize)
+                                                        + (k * test->blockSize)
+                                                        + (j * test->transferSize);
+
+                            if(test->dataPacketType ==  userdata){
+                                offsetArray[offsetCnt].memory = j * test->transferSize;
+                            } else {
+                                offsetArray[offsetCnt].memory = 0;
+                            }
+                            offsetCnt++;
                         }
+                    }
                 }
+            }
         }
+
         /* reorder array */
         for (i = 0; i < offsets; i++) {
                 value = random() % offsets;
@@ -2553,21 +2640,29 @@ static IOR_offset_t *GetOffsetArrayRandom(IOR_param_t * test, int pretendRank,
                 offsetArray[value] = offsetArray[i];
                 offsetArray[i] = tmp;
         }
+
         SeedRandGen(test->testComm);    /* synchronize seeds across tasks */
 
         return (offsetArray);
 }
 
-static IOR_offset_t WriteOrReadSingle(IOR_offset_t pairCnt, IOR_offset_t *offsetArray, int pretendRank,
-  IOR_offset_t * transferCount, int * errors, IOR_param_t * test, int * fd, IOR_io_buffers* ioBuffers, int access){
+static IOR_offset_t WriteOrReadSingle(IOR_offset_t pairCnt,
+                                    IOR_offsetTuple_t *offsetArray,
+                                    int pretendRank,
+                                    IOR_offset_t * transferCount, int * errors,
+                                    IOR_param_t * test, int * fd,
+                                    IOR_io_buffers* ioBuffers, int access)
+  {
   IOR_offset_t amtXferred;
   IOR_offset_t transfer;
 
-  void *buffer = ioBuffers->buffer;
-  void *checkBuffer = ioBuffers->checkBuffer;
-  void *readCheckBuffer = ioBuffers->readCheckBuffer;
+  void *buffer = (void*) ((char*)ioBuffers->buffer + offsetArray[pairCnt].memory);
+  void *checkBuffer = (void*) ((char*)ioBuffers->checkBuffer + offsetArray[pairCnt].memory);
+  void *readCheckBuffer = (void*) ((char*)ioBuffers->readCheckBuffer + offsetArray[pairCnt].memory);
 
-  test->offset = offsetArray[pairCnt];
+  test->offset = offsetArray[pairCnt].file;
+
+
 
   transfer = test->transferSize;
   if (access == WRITE) {
@@ -2622,7 +2717,7 @@ static IOR_offset_t WriteOrRead(IOR_param_t * test, IOR_results_t * results, voi
         IOR_offset_t amtXferred;
         IOR_offset_t transferCount = 0;
         IOR_offset_t pairCnt = 0;
-        IOR_offset_t *offsetArray;
+        IOR_offsetTuple_t *offsetArray;
         int pretendRank;
         IOR_offset_t dataMoved = 0;     /* for data rate calculation */
         double startForStonewall;
@@ -2645,7 +2740,7 @@ static IOR_offset_t WriteOrRead(IOR_param_t * test, IOR_results_t * results, voi
                             > test->deadlineForStonewalling));
 
         /* loop over offsets to access */
-        while ((offsetArray[pairCnt] != -1) && !hitStonewall ) {
+        while ((offsetArray[pairCnt].file != -1) && !hitStonewall ) {
                 dataMoved += WriteOrReadSingle(pairCnt, offsetArray, pretendRank, & transferCount, & errors, test, fd, ioBuffers, access);
                 pairCnt++;
 

--- a/src/ior.h
+++ b/src/ior.h
@@ -55,9 +55,10 @@ extern MPI_Comm testComm;
 enum PACKET_TYPE
 {
     generic = 0,                /* No packet type specified */
-    timestamp=1,                  /* Timestamp packet set with -l */
-    offset=2,                     /* Offset packet set with -l */
-    incompressible=3              /* Incompressible packet set with -l */
+    timestamp=1,                /* Timestamp packet set with -l */
+    offset=2,                   /* Offset packet set with -l */
+    incompressible=3,           /* Incompressible packet set with -l */
+    userdata=4                  /* User data is used to file the buffers */
 
 };
 
@@ -100,6 +101,7 @@ typedef struct
     char platform[MAX_STR];          /* platform type */
     char testFileName[MAXPATHLEN];   /* full name for test */
     char testFileName_fppReadCheck[MAXPATHLEN];/* filename for fpp read check */
+    char pathToInputFile[MAXPATHLEN];/* path to input file */
     char hintsFileName[MAXPATHLEN];  /* full name for hints file */
     char options[MAXPATHLEN];        /* options string */
     int numTasks;                    /* number of tasks for test */
@@ -150,11 +152,12 @@ typedef struct
     unsigned int timeStampSignatureValue; /* value for time stamp signature */
     void * fd_fppReadCheck;          /* additional fd for fpp read check */
     int randomSeed;                  /* random seed for write/read check */
-    int incompressibleSeed;           /* random seed for incompressible file creation */
+    int incompressibleSeed;	     /* random seed for incompressible file creation */
     int randomOffset;                /* access is to random offsets */
     size_t memoryPerTask;            /* additional memory used per task */
     size_t memoryPerNode;            /* additional memory used per node */
-    enum PACKET_TYPE dataPacketType;             /* The type of data packet.  */
+    enum PACKET_TYPE dataPacketType; /* The type of data packet.  */
+    IOR_offset_t userdataFileSize;   /* Size of the file for the userdata from pathtoInputFile */
 
 
     /* POSIX variables */

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -167,6 +167,8 @@ void DecodeDirective(char *line, IOR_param_t *params)
                 strcpy(params->platform, value);
         } else if (strcasecmp(option, "testfile") == 0) {
                 strcpy(params->testFileName, value);
+        } else if (strcasecmp(option, "pathToInputFile") == 0) {
+                strcpy(params->pathToInputFile, value);
         } else if (strcasecmp(option, "hintsfilename") == 0) {
                 strcpy(params->hintsFileName, value);
         } else if (strcasecmp(option, "deadlineforstonewalling") == 0) {
@@ -548,6 +550,9 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
                         case 'o': /* offset packet */
                                 initialTestParams.storeFileOffset = TRUE;
                                 initialTestParams.dataPacketType = offset;
+                                break;
+                        case 'u': /* userdata packet */
+                                initialTestParams.dataPacketType = userdata;
                                 break;
                         default:
                                 fprintf(stdout,


### PR DESCRIPTION
This adds the option to benchmark with user defined data. It is
specifically use full for benchmarking file systems with compression, as
IOR only provides in-compressible or super compressible data (repeating
every 128 bytes). A new flag for the -l (data packet type) `u` is now
present. When this is chosen the data given by the new directive
`pathToInputFile` is read to the buffer. The file has to be at least
the size of blocksize as this is amount of user data used by IOR.
This seams to be sufficient for simulating real data while keeping IOR's
options for access patterns through the parameters transfersize,
blocksize, segmentcount and number of processes working.
This option shouldn't alter IOR's behavior in any other way.
User data should be compatible with Read and Write Checking as the
buffers can be filled with the same data for checking.