### PR TITLE
Option to output results in a json file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,10 +205,22 @@ Consider --with-aws4c=, CPPFLAGS, LDFLAGS, etc])
 ])
 
 
+# Enable json output
+PKG_PROG_PKG_CONFIG
 
-
-
-
+AC_ARG_WITH([json],
+  [AS_HELP_STRING([--with-json],
+    [build with json for output @<:@default=check@:>@])],
+  [],
+  [with_json=check])
+AS_CASE(["$with_json"],
+  [yes], [PKG_CHECK_MODULES([json], [json-c], [HAVE_JSON=1])],
+  [no], [],
+  [PKG_CHECK_MODULES([json], [json-c], [HAVE_JSON=1], [HAVE_JSON=0])])
+AM_CONDITIONAL([USE_JSON], [test "$with_json" != no -a "$HAVE_JSON" -eq 1])
+AM_COND_IF([USE_JSON],[
+        AC_DEFINE([USE_JSON], [], [Build with JSON ouput option])
+])
 
 
 # Enable building "IOR", in all capitals

--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -23,10 +23,10 @@ Index:
 *******************
 * 1.  DESCRIPTION *
 *******************
-IOR can be used for testing performance of parallel file systems using various 
-interfaces and access patterns.  IOR uses MPI for process synchronization.  
-IOR version 2 is a complete rewrite of the original IOR (Interleaved-Or-Random) 
-version 1 code.  
+IOR can be used for testing performance of parallel file systems using various
+interfaces and access patterns.  IOR uses MPI for process synchronization.
+IOR version 2 is a complete rewrite of the original IOR (Interleaved-Or-Random)
+version 1 code.
 
 
 ******************
@@ -39,7 +39,7 @@ Two ways to run IOR:
     E.g., to execute:  IOR -w -r -o filename
     This performs a write and a read to the file 'filename'.
 
-  * Command line with scripts -- any arguments on the command line will 
+  * Command line with scripts -- any arguments on the command line will
     establish the default for the test run, but a script may be used in
     conjunction with this for varying specific tests during an execution of the
     code.
@@ -125,7 +125,7 @@ GENERAL:
                            S3_EMC, or NCMPI, depending on test [POSIX]
 
   * testFile             - name of the output file [testFile]
-                           NOTE: with filePerProc set, the tasks can round 
+                           NOTE: with filePerProc set, the tasks can round
                                  robin across multiple file names '-o S@S@S'
 
   * hintsFileName        - name of the hints file []
@@ -267,7 +267,7 @@ GENERAL:
                                     data, this option measures the amount of
                                     data moved in a fixed amount of time.  The
                                     objective is to prevent tasks slow to
-                                    complete from skewing the performance. 
+                                    complete from skewing the performance.
                                   * setting this to zero (0) unsets this option
                                   * this option is incompatible w/data checking
 
@@ -280,6 +280,9 @@ GENERAL:
   * summaryAlways        - Always print the long summary for each test.
                            Useful for long runs that may be interrupted, preventing
                            the final long summary for ALL tests to be printed.
+  * jsonFileName         - Outputs the results in json format at the given path.
+                           Set so 0 to disable.
+                           (Can be used only when configured with --with-json)
 
 
 POSIX-ONLY:
@@ -319,7 +322,7 @@ HDF5-ONLY:
                            NOTE: default IOR creates a dataset the size of
                                  numTasks * blockSize to be accessed by all
                                  tasks
- 
+
   * noFill               - no pre-filling of data in HDF5 file creation [0=FALSE]
 
   * setAlignment         - HDF5 alignment in bytes (e.g.: 8, 4k, 2m, 1g) [1]
@@ -483,8 +486,8 @@ zip, gzip, and bzip.
 
 2) gzip: For gzipped files, a transfer size of 1k is sufficient.
 
-3) bzip2: For bziped files a transfer size of 1k is insufficient (~50% compressed).  
-   To avoid compression a transfer size of greater than the bzip block size is required 
+3) bzip2: For bziped files a transfer size of 1k is insufficient (~50% compressed).
+   To avoid compression a transfer size of greater than the bzip block size is required
    (default = 900KB). I suggest a transfer size of greather than 1MB to avoid bzip2 compression.
 
 Be aware of the block size your compression algorithm will look at, and adjust the transfer size
@@ -508,9 +511,9 @@ HOW DO I PERFORM MULTIPLE DATA CHECKS ON AN EXISTING FILE?
   and -r implied using both.  This semantic has been subsequently altered to be
   omitting -w, -r, -W, and -R implied using both -w and -r.)
 
-  If you're running new tests to create a file and want repeat data checking on 
-  this file multiple times, there is an undocumented option for this.  It's -O 
-  multiReRead=1, and you'd need to have an IOR version compiled with the 
+  If you're running new tests to create a file and want repeat data checking on
+  this file multiple times, there is an undocumented option for this.  It's -O
+  multiReRead=1, and you'd need to have an IOR version compiled with the
   USE_UNDOC_OPT=1 (in iordef.h).  The command line would look like this:
 
   IOR -k -E -w -W -i 5 -o file -O multiReRead=1
@@ -586,7 +589,7 @@ HOW DO I USE STONEWALLING?
   actually reading the same amount from disk in the allotted time, but they
   are also reading the cached data from the previous test each time to get the
   increased performance.  Setting -D high enough so that the cache is
-  overfilled will prevent this.  
+  overfilled will prevent this.
 
 
 HOW DO I BYPASS CACHING WHEN READING BACK A FILE I'VE JUST WRITTEN?

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,6 +49,12 @@ if USE_POSIX_AIORI
 extraSOURCES += aiori-POSIX.c
 endif
 
+if USE_JSON
+extraCPPFLAGS += $(json_CFLAGS)
+extraLDADD += $(json_LIBS)
+endif
+
+
 
 if USE_S3_AIORI
 extraSOURCES  += aiori-S3.c

--- a/src/ior.c
+++ b/src/ior.c
@@ -2014,7 +2014,7 @@ static void JSONResultsAllTests(IOR_test_t *tests_head)
     }
 
     // write json if filename is not '\0'
-    if (strcmp(tests_head->params.jsonFileName, "\0") == 0){
+    if (strcmp(tests_head->params.jsonFileName, "\0") != 0){
         json_object_to_file_ext(lastJsonFileName, jobj,
                                 JSON_C_TO_STRING_SPACED |
                                 JSON_C_TO_STRING_PRETTY);

--- a/src/ior.c
+++ b/src/ior.c
@@ -1883,6 +1883,7 @@ static void JSONResultsOneOperation(IOR_test_t *test, double *times, char *opera
         IOR_param_t *params = &test->params;
         IOR_results_t *results = test->results;
         struct results *bw;
+        struct results *ops;
         int reps;
 
         if (rank != 0 || verbose < VERBOSE_0)
@@ -1891,18 +1892,36 @@ static void JSONResultsOneOperation(IOR_test_t *test, double *times, char *opera
         reps = params->repetitions;
 
         bw = bw_values(reps, results->aggFileSizeForBW, times);
+        ops = ops_values(reps, results->aggFileSizeForBW,
+                         params->transferSize, times);
 
         json_object_object_add(jobj,"Operation",
                                json_object_new_string(operation));
-        json_object_object_add(jobj,"Max", json_object_new_double(bw->max));
-        json_object_object_add(jobj,"Min", json_object_new_double(bw->min));
-        json_object_object_add(jobj,"Mean", json_object_new_double(bw->mean));
-        json_object_object_add(jobj,"StdDev", json_object_new_double(bw->sd));
+
+        json_object_object_add(jobj,"Bandwidth_Max",
+                               json_object_new_double(bw->max));
+        json_object_object_add(jobj,"Bandwidth_Min",
+                               json_object_new_double(bw->min));
+        json_object_object_add(jobj,"Bandwidth_Mean",
+                               json_object_new_double(bw->mean));
+        json_object_object_add(jobj,"Bandwidth_StdDev",
+                               json_object_new_double(bw->sd));
+
+
+        json_object_object_add(jobj,"IOPS_Max",
+                               json_object_new_double(ops->max));
+        json_object_object_add(jobj,"IOPS_Min",
+                               json_object_new_double(ops->min));
+        json_object_object_add(jobj,"IOPS_Mean",
+                               json_object_new_double(ops->mean));
+        json_object_object_add(jobj,"IOPS_StdDev",
+                               json_object_new_double(ops->sd));
         json_object_object_add(jobj,"MeanTime",
                                json_object_new_double(
-                                   mean_of_array_of_doubles(times, reps)));
+                               mean_of_array_of_doubles(times, reps)));
 
         free(bw);
+        free(ops);
 }
 
 /**
@@ -1942,11 +1961,11 @@ static void JSONResultsOneTest(IOR_test_t *test, json_object * test_jobj)
     json_object_object_add(parameter_jobj,"segmentCount",
                            json_object_new_int(params->segmentCount));
     json_object_object_add(parameter_jobj,"blockSize",
-                           json_object_new_int(params->blockSize));
+                           json_object_new_int64(params->blockSize));
     json_object_object_add(parameter_jobj,"transferSize",
-                           json_object_new_int(params->transferSize));
+                           json_object_new_int64(params->transferSize));
     json_object_object_add(parameter_jobj,"aggFileSize",
-                           json_object_new_int(results->aggFileSizeForBW[0]));
+                           json_object_new_int64(results->aggFileSizeForBW[0]));
     json_object_object_add(parameter_jobj,"API",
                            json_object_new_string(params->api));
     json_object_object_add(parameter_jobj,"referenceNumber",

--- a/src/ior.h
+++ b/src/ior.h
@@ -213,6 +213,11 @@ typedef struct
 
     int id;                          /* test's unique ID */
     int intraTestBarriers;           /* barriers between open/op and op/close */
+
+    /* json output */
+#ifdef USE_JSON
+    char jsonFileName[MAXPATHLEN];   /* Path to the json file for result output */
+#endif
 } IOR_param_t;
 
 /* each pointer is to an array, each of length equal to the number of

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -313,7 +313,7 @@ void DecodeDirective(char *line, IOR_param_t *params)
                         ERR("beegfsNumTargets must be >= 1");
         } else if (strcasecmp(option, "beegfsChunkSize") == 0) {
  #ifndef HAVE_BEEGFS_BEEGFS_H
-                 ERR("ior was not compiled with BeeGFS support"); 
+                 ERR("ior was not compiled with BeeGFS support");
  #endif
                  params->beegfs_chunkSize = StringToBytes(value);
                  if (!ISPOWEROFTWO(params->beegfs_chunkSize) || params->beegfs_chunkSize < (1<<16))
@@ -323,6 +323,15 @@ void DecodeDirective(char *line, IOR_param_t *params)
 		RecalculateExpectedFileSize(params);
         } else if (strcasecmp(option, "summaryalways") == 0) {
                 params->summary_every_test = atoi(value);
+#ifdef USE_JSON
+} else if (strcasecmp(option, "jsonFileName") == 0) {
+            if (strcmp(value, "0") == 0){
+                strcpy(params->jsonFileName, "\0");
+            }
+            else{
+                strcpy(params->jsonFileName, value);
+            }
+#endif
         } else {
                 if (rank == 0)
                         fprintf(stdout, "Unrecognized parameter \"%s\"\n",


### PR DESCRIPTION
This adds an option to output the results in a json file. The new
option is available through the 'jsonFileName' directive. For this to be
present IOR must be configured/compiled with '--with-json' flag. This
adds json-c as dependency and is therefore optional at compile time.