### PR TITLE
Allow block sizes between 1 and 8 bytes

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -362,8 +362,8 @@ CompareBuffers(void *expectedBuffer,
         size_t i, j, length, first, last;
         size_t errorCount = 0;
         int inError = 0;
-        unsigned long long *goodbuf = (unsigned long long *)expectedBuffer;
-        unsigned long long *testbuf = (unsigned long long *)unknownBuffer;
+        IOR_size_t *goodbuf = (IOR_size_t *)expectedBuffer;
+        IOR_size_t *testbuf = (IOR_size_t *)unknownBuffer;
 
         if (access == WRITECHECK || access == READCHECK) {
                 strcpy(bufferLabel1, "Expected: ");

--- a/src/iordef.h
+++ b/src/iordef.h
@@ -117,7 +117,7 @@ extern int verbose;                            /* verbose output */
                                    __LINE__, rank);
 
 typedef long long int      IOR_offset_t;
-typedef long long int      IOR_size_t;
+typedef char               IOR_size_t;
 
 #define                    IOR_format "%016llx"
 

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -116,8 +116,6 @@ void DumpBuffer(void *buffer,
         size_t i, j;
         IOR_size_t *dumpBuf = (IOR_size_t *)buffer;
 
-        /* Turns out, IOR_size_t is unsigned long long, but we don't want
-           to assume that it must always be */
         for (i = 0; i < ((size / sizeof(IOR_size_t)) / 4); i++) {
                 for (j = 0; j < 4; j++) {
                         fprintf(stdout, IOR_format" ", dumpBuf[4 * i + j]);


### PR DESCRIPTION
IOR_size_t was defined as long long which prevents using
block sizes below 8 bytes. This patch makes small changes
to be able to run IOR with blocks between 1 and 8 bytes.