### PR TITLE
Add OPs result columns back

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1686,6 +1686,41 @@ static struct results *bw_values(int reps, IOR_offset_t *agg_file_size, double *
         return r;
 }
 
+static struct results *ops_values(int reps, IOR_offset_t *agg_file_size,
+                                  IOR_offset_t transfer_size,
+                                  double *vals)
+{
+        struct results *r;
+        int i;
+
+        r = (struct results *)malloc(sizeof(struct results)
+                                     + (reps * sizeof(double)));
+        if (r == NULL)
+                ERR("malloc failed");
+        r->val = (double *)&r[1];
+
+        for (i = 0; i < reps; i++) {
+                r->val[i] = (double)agg_file_size[i] / transfer_size / vals[i];
+                if (i == 0) {
+                        r->min = r->val[i];
+                        r->max = r->val[i];
+                        r->sum = 0.0;
+                }
+                r->min = MIN(r->min, r->val[i]);
+                r->max = MAX(r->max, r->val[i]);
+                r->sum += r->val[i];
+        }
+        r->mean = r->sum / reps;
+        r->var = 0.0;
+        for (i = 0; i < reps; i++) {
+                r->var += pow((r->mean - r->val[i]), 2);
+        }
+        r->var = r->var / reps;
+        r->sd = sqrt(r->var);
+
+        return r;
+}
+
 /*
  * Summarize results
  *
@@ -1696,6 +1731,7 @@ static void PrintLongSummaryOneOperation(IOR_test_t *test, double *times, char *
         IOR_param_t *params = &test->params;
         IOR_results_t *results = test->results;
         struct results *bw;
+        struct results *ops;
         int reps;
 
         if (rank != 0 || verbose < VERBOSE_0)
@@ -1704,12 +1740,18 @@ static void PrintLongSummaryOneOperation(IOR_test_t *test, double *times, char *
         reps = params->repetitions;
 
         bw = bw_values(reps, results->aggFileSizeForBW, times);
+        ops = ops_values(reps, results->aggFileSizeForBW,
+                         params->transferSize, times);
 
         fprintf(stdout, "%-9s ", operation);
         fprintf(stdout, "%10.2f ", bw->max / MEBIBYTE);
         fprintf(stdout, "%10.2f ", bw->min / MEBIBYTE);
         fprintf(stdout, "%10.2f ", bw->mean / MEBIBYTE);
         fprintf(stdout, "%10.2f ", bw->sd / MEBIBYTE);
+        fprintf(stdout, "%10.2f ", ops->max);
+        fprintf(stdout, "%10.2f ", ops->min);
+        fprintf(stdout, "%10.2f ", ops->mean);
+        fprintf(stdout, "%10.2f ", ops->sd);
         fprintf(stdout, "%10.5f ",
                 mean_of_array_of_doubles(times, reps));
         fprintf(stdout, "%d ", params->id);
@@ -1731,6 +1773,7 @@ static void PrintLongSummaryOneOperation(IOR_test_t *test, double *times, char *
         fflush(stdout);
 
         free(bw);
+        free(ops);
 }
 
 static void PrintLongSummaryOneTest(IOR_test_t *test)
@@ -1750,8 +1793,9 @@ static void PrintLongSummaryHeader()
                 return;
 
         fprintf(stdout, "\n");
-        fprintf(stdout, "%-9s %10s %10s %10s %10s %10s",
+        fprintf(stdout, "%-9s %10s %10s %10s %10s %10s %10s %10s %10s %10s",
                 "Operation", "Max(MiB)", "Min(MiB)", "Mean(MiB)", "StdDev",
+                "Max(OPs)", "Min(OPs)", "Mean(OPs)", "StdDev",
                 "Mean(s)");
         fprintf(stdout, " Test# #Tasks tPN reps fPP reord reordoff reordrand seed"
                 " segcnt blksiz xsize aggsize API RefNum\n");


### PR DESCRIPTION
IOPS accounting should work with stonewall as well since now we calculate the results based on actual bytes transferred.

Signed-off-by: Li Dongyang <dongyangli@ddn.com>