### PR TITLE
fix IOR access dependency

### DIFF
--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -92,6 +92,7 @@ static void HDF5_Delete(char *, IOR_param_t *);
 static void HDF5_SetVersion(IOR_param_t *);
 static void HDF5_Fsync(void *, IOR_param_t *);
 static IOR_offset_t HDF5_GetFileSize(IOR_param_t *, MPI_Comm, char *);
+static int HDF5_Access(const char *, int, IOR_param_t *);
 
 /************************** D E C L A R A T I O N S ***************************/
 
@@ -105,6 +106,11 @@ ior_aiori_t hdf5_aiori = {
         .set_version = HDF5_SetVersion,
         .fsync = HDF5_Fsync,
         .get_file_size = HDF5_GetFileSize,
+        .statfs = aiori_posix_statfs,
+        .mkdir = aiori_posix_mkdir,
+        .rmdir = aiori_posix_rmdir,
+        .access = HDF5_Access,
+        .stat = aiori_posix_stat,
 };
 
 static hid_t xferPropList;      /* xfer property list */
@@ -435,8 +441,7 @@ static void HDF5_Close(void *fd, IOR_param_t * param)
  */
 static void HDF5_Delete(char *testFileName, IOR_param_t * param)
 {
-        if (unlink(testFileName) != 0)
-                WARN("cannot delete file");
+        return(MPIIO_Delete(testFileName, param));
 }
 
 /*
@@ -565,5 +570,13 @@ static void SetupDataSet(void *fd, IOR_param_t * param)
 static IOR_offset_t
 HDF5_GetFileSize(IOR_param_t * test, MPI_Comm testComm, char *testFileName)
 {
-        return (MPIIO_GetFileSize(test, testComm, testFileName));
+        return(MPIIO_GetFileSize(test, testComm, testFileName));
+}
+
+/*
+ * Use MPIIO call to check for access.
+ */
+static int HDF5_Access(const char *path, int mode, IOR_param_t *param)
+{
+        return(MPIIO_Access(path, mode, param));
 }

--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -53,7 +53,11 @@ ior_aiori_t mpiio_aiori = {
         .set_version = MPIIO_SetVersion,
         .fsync = MPIIO_Fsync,
         .get_file_size = MPIIO_GetFileSize,
+        .statfs = aiori_posix_statfs,
+        .mkdir = aiori_posix_mkdir,
+        .rmdir = aiori_posix_rmdir,
         .access = MPIIO_Access,
+        .stat = aiori_posix_stat,
 };
 
 /***************************** F U N C T I O N S ******************************/

--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -38,10 +38,8 @@ static void *MPIIO_Open(char *, IOR_param_t *);
 static IOR_offset_t MPIIO_Xfer(int, void *, IOR_size_t *,
                                    IOR_offset_t, IOR_param_t *);
 static void MPIIO_Close(void *, IOR_param_t *);
-static void MPIIO_Delete(char *, IOR_param_t *);
 static void MPIIO_SetVersion(IOR_param_t *);
 static void MPIIO_Fsync(void *, IOR_param_t *);
-static int MPIIO_Access(const char *, int, IOR_param_t *);
 
 /************************** D E C L A R A T I O N S ***************************/
 
@@ -59,30 +57,6 @@ ior_aiori_t mpiio_aiori = {
 };
 
 /***************************** F U N C T I O N S ******************************/
-
-/*
- * Try to access a file through the MPIIO interface.
- */
-static int MPIIO_Access(const char *path, int mode, IOR_param_t *param)
-{
-    MPI_File fd;
-    int mpi_mode = MPI_MODE_UNIQUE_OPEN;
-
-    if ((mode & W_OK) && (mode & R_OK))
-        mpi_mode |= MPI_MODE_RDWR;
-    else if (mode & W_OK)
-        mpi_mode |= MPI_MODE_WRONLY;
-    else
-        mpi_mode |= MPI_MODE_RDONLY;
-
-    int ret = MPI_File_open(MPI_COMM_SELF, path, mpi_mode,
-                            MPI_INFO_NULL, &fd);
-
-    if (!ret)
-        MPI_File_close(&fd);
-
-    return ret;
-}
 
 /*
  * Create and open a file through the MPIIO interface.
@@ -396,7 +370,7 @@ static void MPIIO_Close(void *fd, IOR_param_t * param)
 /*
  * Delete a file through the MPIIO interface.
  */
-static void MPIIO_Delete(char *testFileName, IOR_param_t * param)
+void MPIIO_Delete(char *testFileName, IOR_param_t * param)
 {
         MPI_CHECK(MPI_File_delete(testFileName, (MPI_Info) MPI_INFO_NULL),
                   "cannot delete file");
@@ -494,4 +468,28 @@ IOR_offset_t MPIIO_GetFileSize(IOR_param_t * test, MPI_Comm testComm,
         }
 
         return (aggFileSizeFromStat);
+}
+
+/*
+ * Try to access a file through the MPIIO interface.
+ */
+int MPIIO_Access(const char *path, int mode, IOR_param_t *param)
+{
+    MPI_File fd;
+    int mpi_mode = MPI_MODE_UNIQUE_OPEN;
+
+    if ((mode & W_OK) && (mode & R_OK))
+        mpi_mode |= MPI_MODE_RDWR;
+    else if (mode & W_OK)
+        mpi_mode |= MPI_MODE_WRONLY;
+    else
+        mpi_mode |= MPI_MODE_RDONLY;
+
+    int ret = MPI_File_open(MPI_COMM_SELF, path, mpi_mode,
+                            MPI_INFO_NULL, &fd);
+
+    if (!ret)
+        MPI_File_close(&fd);
+
+    return ret;
 }

--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -56,6 +56,7 @@ static void NCMPI_Delete(char *, IOR_param_t *);
 static void NCMPI_SetVersion(IOR_param_t *);
 static void NCMPI_Fsync(void *, IOR_param_t *);
 static IOR_offset_t NCMPI_GetFileSize(IOR_param_t *, MPI_Comm, char *);
+static int NCMPI_Access(const char *, int, IOR_param_t *);
 
 /************************** D E C L A R A T I O N S ***************************/
 
@@ -69,6 +70,11 @@ ior_aiori_t ncmpi_aiori = {
         .set_version = NCMPI_SetVersion,
         .fsync = NCMPI_Fsync,
         .get_file_size = NCMPI_GetFileSize,
+        .statfs = aiori_posix_statfs,
+        .mkdir = aiori_posix_mkdir,
+        .rmdir = aiori_posix_rmdir,
+        .access = NCMPI_Access,
+        .stat = aiori_posix_stat,
 };
 
 /***************************** F U N C T I O N S ******************************/
@@ -329,8 +335,7 @@ static void NCMPI_Close(void *fd, IOR_param_t * param)
  */
 static void NCMPI_Delete(char *testFileName, IOR_param_t * param)
 {
-        if (unlink(testFileName) != 0)
-                WARN("unlink() failed");
+        return(MPIIO_Delete(testFileName, param));
 }
 
 /*
@@ -387,5 +392,13 @@ static int GetFileMode(IOR_param_t * param)
 static IOR_offset_t NCMPI_GetFileSize(IOR_param_t * test, MPI_Comm testComm,
                                       char *testFileName)
 {
-        return (MPIIO_GetFileSize(test, testComm, testFileName));
+        return(MPIIO_GetFileSize(test, testComm, testFileName));
+}
+
+/*
+ * Use MPIIO call to check for access.
+ */
+static int NCMPI_Access(const char *path, int mode, IOR_param_t *param)
+{
+        return(MPIIO_Access(path, mode, param));
 }

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -87,6 +87,11 @@ ior_aiori_t posix_aiori = {
         .set_version = POSIX_SetVersion,
         .fsync = POSIX_Fsync,
         .get_file_size = POSIX_GetFileSize,
+        .statfs = aiori_posix_statfs,
+        .mkdir = aiori_posix_mkdir,
+        .rmdir = aiori_posix_rmdir,
+        .access = aiori_posix_access,
+        .stat = aiori_posix_stat,
 };
 
 /***************************** F U N C T I O N S ******************************/

--- a/src/aiori.c
+++ b/src/aiori.c
@@ -61,7 +61,7 @@ ior_aiori_t *available_aiori[] = {
  * This function provides a AIORI statfs for POSIX-compliant filesystems. It
  * uses statvfs is available and falls back on statfs.
  */
-static int aiori_statfs (const char *path, ior_aiori_statfs_t *stat_buf, IOR_param_t * param)
+int aiori_posix_statfs (const char *path, ior_aiori_statfs_t *stat_buf, IOR_param_t * param)
 {
         int ret;
 #if defined(HAVE_STATVFS)
@@ -86,44 +86,60 @@ static int aiori_statfs (const char *path, ior_aiori_statfs_t *stat_buf, IOR_par
         return 0;
 }
 
-static int aiori_mkdir (const char *path, mode_t mode, IOR_param_t * param)
+int aiori_posix_mkdir (const char *path, mode_t mode, IOR_param_t * param)
 {
         return mkdir (path, mode);
 }
 
-static int aiori_rmdir (const char *path, IOR_param_t * param)
+int aiori_posix_rmdir (const char *path, IOR_param_t * param)
 {
         return rmdir (path);
 }
 
-static int aiori_access (const char *path, int mode, IOR_param_t * param)
+int aiori_posix_access (const char *path, int mode, IOR_param_t * param)
 {
         return access (path, mode);
 }
 
-static int aiori_stat (const char *path, struct stat *buf, IOR_param_t * param)
+int aiori_posix_stat (const char *path, struct stat *buf, IOR_param_t * param)
 {
         return stat (path, buf);
 }
 
 const ior_aiori_t *aiori_select (const char *api)
 {
+        char warn_str[256] = {0};
         for (ior_aiori_t **tmp = available_aiori ; *tmp != NULL; ++tmp) {
                 if (NULL == api || strcasecmp(api, (*tmp)->name) == 0) {
                         if (NULL == (*tmp)->statfs) {
-                                (*tmp)->statfs = aiori_statfs;
+                                (*tmp)->statfs = aiori_posix_statfs;
+                                snprintf(warn_str, 256, "assuming POSIX-based backend for"
+                                         " %s statfs call", api);
+                                WARN(warn_str);
                         }
                         if (NULL == (*tmp)->mkdir) {
-                                (*tmp)->mkdir = aiori_mkdir;
+                                (*tmp)->mkdir = aiori_posix_mkdir;
+                                snprintf(warn_str, 256, "assuming POSIX-based backend for"
+                                         " %s mkdir call", api);
+                                WARN(warn_str);
                         }
                         if (NULL == (*tmp)->rmdir) {
-                                (*tmp)->rmdir = aiori_rmdir;
+                                (*tmp)->rmdir = aiori_posix_rmdir;
+                                snprintf(warn_str, 256, "assuming POSIX-based backend for"
+                                         " %s rmdir call", api);
+                                WARN(warn_str);
                         }
                         if (NULL == (*tmp)->access) {
-                                (*tmp)->access = aiori_access;
+                                (*tmp)->access = aiori_posix_access;
+                                snprintf(warn_str, 256, "assuming POSIX-based backend for"
+                                         " %s access call", api);
+                                WARN(warn_str);
                         }
                         if (NULL == (*tmp)->stat) {
-                                (*tmp)->stat = aiori_stat;
+                                (*tmp)->stat = aiori_posix_stat;
+                                snprintf(warn_str, 256, "assuming POSIX-based backend for"
+                                         " %s stat call", api);
+                                WARN(warn_str);
                         }
                         return *tmp;
                 }

--- a/src/aiori.h
+++ b/src/aiori.h
@@ -92,6 +92,13 @@ const ior_aiori_t *aiori_select (const char *api);
 int aiori_count (void);
 const char *aiori_default (void);
 
+/* some generic POSIX-based backend calls */
+int aiori_posix_statfs (const char *path, ior_aiori_statfs_t *stat_buf, IOR_param_t * param);
+int aiori_posix_mkdir (const char *path, mode_t mode, IOR_param_t * param);
+int aiori_posix_rmdir (const char *path, IOR_param_t * param);
+int aiori_posix_access (const char *path, int mode, IOR_param_t * param);
+int aiori_posix_stat (const char *path, struct stat *buf, IOR_param_t * param);
+
 IOR_offset_t MPIIO_GetFileSize(IOR_param_t * test, MPI_Comm testComm,
                                char *testFileName);
 

--- a/src/aiori.h
+++ b/src/aiori.h
@@ -99,7 +99,10 @@ int aiori_posix_rmdir (const char *path, IOR_param_t * param);
 int aiori_posix_access (const char *path, int mode, IOR_param_t * param);
 int aiori_posix_stat (const char *path, struct stat *buf, IOR_param_t * param);
 
+/* NOTE: these 3 MPI-IO functions are exported for reuse by HDF5/PNetCDF */
+void MPIIO_Delete(char *testFileName, IOR_param_t * param);
 IOR_offset_t MPIIO_GetFileSize(IOR_param_t * test, MPI_Comm testComm,
                                char *testFileName);
+int MPIIO_Access(const char *, int, IOR_param_t *);
 
 #endif /* not _AIORI_H */

--- a/src/ior.c
+++ b/src/ior.c
@@ -1272,7 +1272,7 @@ static void RemoveFile(char *testFileName, int filePerProc, IOR_param_t * test)
                         rankOffset = 0;
                         GetTestFileName(testFileName, test);
                 }
-                if (access(testFileName, F_OK) == 0) {
+                if (backend->access(testFileName, F_OK, test) == 0) {
                         backend->delete(testFileName, test);
                 }
                 if (test->reorderTasksRandom == TRUE) {
@@ -1280,13 +1280,7 @@ static void RemoveFile(char *testFileName, int filePerProc, IOR_param_t * test)
                         GetTestFileName(testFileName, test);
                 }
         } else {
-                // BUG: "access()" assumes a POSIX filesystem.  Maybe use
-                //      backend->get_file_size(), instead, (and catch
-                //      errors), or extend the aiori struct to include
-                //      something to safely check for existence of the
-                //      "file".
-                //
-                if ((rank == 0) && (access(testFileName, F_OK) == 0)) {
+                if ((rank == 0) && (backend->access(testFileName, F_OK, test) == 0)) {
                         backend->delete(testFileName, test);
                 }
         }


### PR DESCRIPTION
I'm recycling this from my earlier pull request (#36) that I botched, though the net result in each case is basically the same. Just wanted to clean up the git history which was a mess.

To summarize, this pull request should resolve issue #35 by breaking IOR's dependence on the `access()` call which is used in the IOR's file delete code path. This resolves a longstanding problem of not being able to remove IOR output "files" on non-POSIX backends. 

Summary of the changes:
- Expose the generic `aiori_` calls for `access()`, `mkdir()`, etc. so that backends can opt-in to them explicitly. POSIX, MPIIO, HDF5, and NCMPI backends all now explicitly set which of these generic functions they want to use.
- Expose MPIIO backend routines for `access()` and `delete()`. Now, the HDF5 and NCMPI backends use these MPIIO routines directly rather than implementing their own or using generic ones offered in `aiori`. Similar to the `file_get_size()` call, it's easier/cleaner for the HDF5/NCMPI backends to rely on MPIIO to check whether a file exists or to delete a file.
- IOR now no longer uses `access()` directly to check for a file's existence before deleting, and instead calls the correspoding `backend->access()` routine.

I have tested using both NCMPI and HDF5 backends and things appear to be working fine.