### PR TITLE
use MPI_COMM_SELF when opening file to get file size in MPIIO

### DIFF
--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -464,8 +464,15 @@ IOR_offset_t MPIIO_GetFileSize(IOR_param_t * test, MPI_Comm testComm,
 {
         IOR_offset_t aggFileSizeFromStat, tmpMin, tmpMax, tmpSum;
         MPI_File fd;
+        MPI_Comm comm;
 
-        MPI_CHECK(MPI_File_open(testComm, testFileName, MPI_MODE_RDONLY,
+        if (test->filePerProc == TRUE) {
+                comm = MPI_COMM_SELF;
+        } else {
+                comm = testComm;
+        }
+
+        MPI_CHECK(MPI_File_open(comm, testFileName, MPI_MODE_RDONLY,
                                 MPI_INFO_NULL, &fd),
                   "cannot open file to get file size");
         MPI_CHECK(MPI_File_get_size(fd, (MPI_Offset *) & aggFileSizeFromStat),


### PR DESCRIPTION
MPI requires all ranks to refer to the same file within the communicator passed to MPI_File_open.

This bug was exposed during testing with Open MPI and BeeGFS.  Without it, a run produces an error like the following:

srun -N2 -n4 ./install/bin/ior -a MPIIO -b 10MB -t 1MB -v -F -w -o /p/bscratcha/moody20/IOR_MANUAL

<snip>

Commencing write performance test: Wed May 16 13:22:31 2018
[catalyst105:75531] [1]mca_sharedfp_lockedfile_file_open: Error during file open
[catalyst106:37197] [2]mca_sharedfp_lockedfile_file_open: Error during file open
[catalyst106:37198] [3]mca_sharedfp_lockedfile_file_open: Error during file open
