### PR TITLE
More fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,7 @@ AC_ARG_WITH([lustre],
                 [support configurable Lustre striping values @<:@default=check@:>@])],
         [], [with_lustre=check])
 AS_IF([test "x$with_lustre" != xno], [
-        AC_CHECK_HEADERS([lustre/lustre_user.h], [], [
+        AC_CHECK_HEADERS([linux/lustre/lustre_user.h lustre/lustre_user.h], break, [
                 if test "x$with_lustre" != xcheck; then
                         AC_MSG_FAILURE([--with-lustre was given, <lustre/lustre_user.h> not found])
                 fi

--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -53,7 +53,7 @@ static IOR_offset_t NCMPI_Xfer(int, void *, IOR_size_t *,
                                IOR_offset_t, IOR_param_t *);
 static void NCMPI_Close(void *, IOR_param_t *);
 static void NCMPI_Delete(char *, IOR_param_t *);
-static char *NCMPI_GetVersion(IOR_param_t *);
+static char *NCMPI_GetVersion();
 static void NCMPI_Fsync(void *, IOR_param_t *);
 static IOR_offset_t NCMPI_GetFileSize(IOR_param_t *, MPI_Comm, char *);
 static int NCMPI_Access(const char *, int, IOR_param_t *);

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -31,8 +31,12 @@
 #include <sys/stat.h>
 #include <assert.h>
 
+
 #ifdef HAVE_LUSTRE_LUSTRE_USER_H
 #  include <lustre/lustre_user.h>
+#endif
+#ifdef HAVE_LINUX_LUSTRE_LUSTRE_USER_H
+#  include <linux/lustre/lustre_user.h>
 #endif
 #ifdef HAVE_GPFS_H
 #  include <gpfs.h>


### PR DESCRIPTION
gcc-7.3 did not like prototype and definition of NCMPI_GetVersion having different arguments

newer lustre will say "including lustre_user.h directly is deprecated", so feel free to have the same configure tests I used in ROMIO.