### PR TITLE
Check provided IO API is valid

### DIFF
--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -541,6 +541,9 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
         }
 
         const ior_aiori_t * backend = aiori_select(initialTestParams.api);
+        if (backend == NULL)
+            ERR_SIMPLE("unrecognized I/O API");
+
         initialTestParams.backend = backend;
         initialTestParams.apiVersion = backend->get_version();
 


### PR DESCRIPTION
Context: IOR gets a segfault if an unsupported API string
is provided.

This patch checks that the I/O backend is supported, otherwise
IOR stops with an error.