### PR TITLE
Initialize only the required backends

### DIFF
--- a/src/aiori.h
+++ b/src/aiori.h
@@ -97,8 +97,8 @@ extern ior_aiori_t s3_plus_aiori;
 extern ior_aiori_t s3_emc_aiori;
 extern ior_aiori_t rados_aiori;
 
-void aiori_initialize();
-void aiori_finalize();
+void aiori_initialize(IOR_test_t * tests);
+void aiori_finalize(IOR_test_t * tests);
 const ior_aiori_t *aiori_select (const char *api);
 int aiori_count (void);
 void aiori_supported_apis(char * APIs);

--- a/src/ior.c
+++ b/src/ior.c
@@ -98,8 +98,6 @@ int ior_main(int argc, char **argv)
     out_logfile = stdout;
     out_resultfile = stdout;
 
-    aiori_initialize();
-
     /*
      * check -h option from commandline without starting MPI;
      */
@@ -122,6 +120,8 @@ int ior_main(int argc, char **argv)
     /* setup tests, and validate parameters */
     InitTests(tests_head, mpi_comm_world);
     verbose = tests_head->params.verbose;
+
+    aiori_initialize(tests_head);
 
     PrintHeader(argc, argv);
 
@@ -151,11 +151,11 @@ int ior_main(int argc, char **argv)
     /* display finish time */
     PrintTestEnds();
 
-    DestroyTests(tests_head);
-
     MPI_CHECK(MPI_Finalize(), "cannot finalize MPI");
 
-    aiori_finalize();
+    aiori_finalize(tests_head);
+
+    DestroyTests(tests_head);
 
     return totalErrorCount;
 }

--- a/src/ior.h
+++ b/src/ior.h
@@ -77,9 +77,11 @@ typedef struct IO_BUFFERS
  *         USER_GUIDE
  */
 
+struct ior_aiori;
+
 typedef struct
 {
-    const void * backend;
+    const struct ior_aiori * backend;
     char * debug;             /* debug info string */
     unsigned int mode;               /* file permissions */
     unsigned int openFlags;          /* open flags (see also <open>) */

--- a/src/mdtest-main.c
+++ b/src/mdtest-main.c
@@ -2,12 +2,12 @@
 #include "aiori.h"
 
 int main(int argc, char **argv) {
-    aiori_initialize();
+    aiori_initialize(NULL);
     MPI_Init(&argc, &argv);
 
     mdtest_run(argc, argv, MPI_COMM_WORLD, stdout);
 
     MPI_Finalize();
-    aiori_finalize();
+    aiori_finalize(NULL);
     return 0;
 }


### PR DESCRIPTION
Context: IOR initializes all available backends. If one
backend fails to initialize IOR cannot be used.

This patch makes IOR initialize only the backends
which will be used. The initialization is done after
that the parameters are checked so that the help message
can still be dispayed is something goes wrong.