### PR TITLE
Make write verification work even without read test

### DIFF
--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -88,9 +88,8 @@ static void CheckRunSettings(IOR_test_t *tests)
                  * (We assume int-valued params are exclusively 0 or 1.)
                  */
                 if ((params->openFlags & IOR_RDWR)
-                    && ((params->readFile | params->checkRead)
-                        ^ (params->writeFile | params->checkWrite))
-                    && (params->openFlags & IOR_RDWR)) {
+                    && ((params->readFile | params->checkRead | params->checkWrite)
+                        ^ params->writeFile)) {
 
                         params->openFlags &= ~(IOR_RDWR);
                         if (params->readFile | params->checkRead) {
@@ -100,7 +99,6 @@ static void CheckRunSettings(IOR_test_t *tests)
                         else
                                 params->openFlags |= IOR_WRONLY;
                 }
-
         }
 }
 


### PR DESCRIPTION
Context: IOR outputs errors when the '-w -W' flags are used
without '-r'. Write a file using with check write option
should be possible even without setting read.

This patch fixes a condition which was introduced for
HDFS to remove RDWR flag in some particular cases.
Write check was set with the write only flag but it
requieres the read flag.