### PR TITLE
 Fix erroneous reported write bandwidth with stonewalling

### DIFF
--- a/src/ior-output.c
+++ b/src/ior-output.c
@@ -385,10 +385,12 @@ void ShowTestStart(IOR_param_t *test)
 
 void ShowTestEnd(IOR_test_t *tptr){
   if(rank == 0 && tptr->params.stoneWallingWearOut){
+
+    size_t pairs_accessed = tptr->results->write.pairs_accessed;
     if (tptr->params.stoneWallingStatusFile){
-      StoreStoneWallingIterations(tptr->params.stoneWallingStatusFile, tptr->results->pairs_accessed);
+      StoreStoneWallingIterations(tptr->params.stoneWallingStatusFile, pairs_accessed);
     }else{
-      fprintf(out_logfile, "Pairs deadlineForStonewallingaccessed: %lld\n", (long long) tptr->results->pairs_accessed);
+      fprintf(out_logfile, "Pairs deadlineForStonewallingaccessed: %ld\n", pairs_accessed);
     }
   }
   PrintEndSection();
@@ -455,8 +457,8 @@ void ShowSetup(IOR_param_t *params)
 }
 
 static struct results *bw_ops_values(const int reps, IOR_results_t *measured,
-                                     const int offset, IOR_offset_t transfer_size,
-                                     const double *vals)
+                                     IOR_offset_t transfer_size,
+                                     const double *vals, const int access)
 {
         struct results *r;
         int i;
@@ -468,7 +470,10 @@ static struct results *bw_ops_values(const int reps, IOR_results_t *measured,
         r->val = (double *)&r[1];
 
         for (i = 0; i < reps; i++, measured++) {
-                r->val[i] = (double) *((IOR_offset_t*) ((char*)measured + offset))
+                IOR_point_t *point = (access == WRITE) ? &measured->write :
+                                                         &measured->read;
+
+                r->val[i] = ((double) (point->aggFileSizeForBW))
                             / transfer_size / vals[i];
 
                 if (i == 0) {
@@ -492,24 +497,22 @@ static struct results *bw_ops_values(const int reps, IOR_results_t *measured,
 }
 
 static struct results *bw_values(const int reps, IOR_results_t *measured,
-                                 const int offset, const double *vals)
+                                 const double *vals, const int access)
 {
-        return bw_ops_values(reps, measured, offset, 1, vals);
+        return bw_ops_values(reps, measured, 1, vals, access);
 }
 
 static struct results *ops_values(const int reps, IOR_results_t *measured,
-                                  const int offset, IOR_offset_t transfer_size,
-                                  const double *vals)
+                                  IOR_offset_t transfer_size,
+                                  const double *vals, const int access)
 {
-        return bw_ops_values(reps, measured, offset, transfer_size, vals);
+        return bw_ops_values(reps, measured, transfer_size, vals, access);
 }
 
 /*
  * Summarize results
- *
- * operation is typically "write" or "read"
  */
-static void PrintLongSummaryOneOperation(IOR_test_t *test, int times_offset, char *operation)
+static void PrintLongSummaryOneOperation(IOR_test_t *test, const int access)
 {
         IOR_param_t *params = &test->params;
         IOR_results_t *results = test->results;
@@ -524,14 +527,20 @@ static void PrintLongSummaryOneOperation(IOR_test_t *test, int times_offset, cha
 
         double * times = malloc(sizeof(double)* reps);
         for(int i=0; i < reps; i++){
-          times[i] = *(double*)((char*) & results[i] + times_offset);
+                IOR_point_t *point = (access == WRITE) ? &results[i].write :
+                                                         &results[i].read;
+                times[i] = point->time;
         }
 
-        bw = bw_values(reps, results, offsetof(IOR_results_t, aggFileSizeForBW), times);
-        ops = ops_values(reps, results, offsetof(IOR_results_t, aggFileSizeForBW), params->transferSize, times);
+        bw = bw_values(reps, results, times, access);
+        ops = ops_values(reps, results, params->transferSize, times, access);
+
+        IOR_point_t *point = (access == WRITE) ? &results[0].write :
+                                                 &results[0].read;
+
 
         if(outputFormat == OUTPUT_DEFAULT){
-          fprintf(out_resultfile, "%-9s ", operation);
+          fprintf(out_resultfile, "%-9s ", access == WRITE ? "write" : "read");
           fprintf(out_resultfile, "%10.2f ", bw->max / MEBIBYTE);
           fprintf(out_resultfile, "%10.2f ", bw->min / MEBIBYTE);
           fprintf(out_resultfile, "%10.2f ", bw->mean / MEBIBYTE);
@@ -553,13 +562,13 @@ static void PrintLongSummaryOneOperation(IOR_test_t *test, int times_offset, cha
           fprintf(out_resultfile, "%6lld ", params->segmentCount);
           fprintf(out_resultfile, "%8lld ", params->blockSize);
           fprintf(out_resultfile, "%8lld ", params->transferSize);
-          fprintf(out_resultfile, "%9.1f ", (float)results[0].aggFileSizeForBW / MEBIBYTE);
+          fprintf(out_resultfile, "%9.1f ", (float)point->aggFileSizeForBW / MEBIBYTE);
           fprintf(out_resultfile, "%3s ", params->api);
           fprintf(out_resultfile, "%6d", params->referenceNumber);
           fprintf(out_resultfile, "\n");
         }else if (outputFormat == OUTPUT_JSON){
           PrintStartSection();
-          PrintKeyVal("operation", operation);
+          PrintKeyVal("operation", access == WRITE ? "write" : "read");
           PrintKeyVal("API", params->api);
           PrintKeyValInt("TestID", params->id);
           PrintKeyValInt("ReferenceNumber", params->referenceNumber);
@@ -586,7 +595,7 @@ static void PrintLongSummaryOneOperation(IOR_test_t *test, int times_offset, cha
           PrintKeyValDouble("OPsMean", ops->mean);
           PrintKeyValDouble("OPsSD", ops->sd);
           PrintKeyValDouble("MeanTime", mean_of_array_of_doubles(times, reps));
-          PrintKeyValDouble("xsizeMiB", (double) results[0].aggFileSizeForBW / MEBIBYTE);
+          PrintKeyValDouble("xsizeMiB", (double) point->aggFileSizeForBW / MEBIBYTE);
           PrintEndSection();
         }else if (outputFormat == OUTPUT_CSV){
 
@@ -604,9 +613,9 @@ void PrintLongSummaryOneTest(IOR_test_t *test)
         IOR_param_t *params = &test->params;
 
         if (params->writeFile)
-                PrintLongSummaryOneOperation(test, offsetof(IOR_results_t, writeTime), "write");
+                PrintLongSummaryOneOperation(test, WRITE);
         if (params->readFile)
-                PrintLongSummaryOneOperation(test, offsetof(IOR_results_t, readTime), "read");
+                PrintLongSummaryOneOperation(test, READ);
 }
 
 void PrintLongSummaryHeader()
@@ -672,9 +681,9 @@ void PrintShortSummary(IOR_test_t * test)
         reps = params->repetitions;
 
         for (i = 0; i < reps; i++) {
-                bw = (double)results[i].aggFileSizeForBW / results[i].writeTime;
+                bw = (double)results[i].write.aggFileSizeForBW / results[i].write.time;
                 max_write_bw = MAX(bw, max_write_bw);
-                bw = (double)results[i].aggFileSizeForBW / results[i].readTime;
+                bw = (double)results[i].read.aggFileSizeForBW / results[i].read.time;
                 max_read_bw = MAX(bw, max_read_bw);
         }
 

--- a/src/ior.h
+++ b/src/ior.h
@@ -204,12 +204,9 @@ typedef struct
     int intraTestBarriers;           /* barriers between open/op and op/close */
 } IOR_param_t;
 
-/* each pointer is to an array, each of length equal to the number of
-   repetitions in the test */
+/* each pointer for a single test */
 typedef struct {
-   double writeTime;
-   double readTime;
-   int    errors;
+   double time;
    size_t pairs_accessed; // number of I/Os done, useful for deadlineForStonewalling
 
    double     stonewall_time;
@@ -219,15 +216,20 @@ typedef struct {
    IOR_offset_t aggFileSizeFromStat;
    IOR_offset_t aggFileSizeFromXfer;
    IOR_offset_t aggFileSizeForBW;
+} IOR_point_t;
+
+typedef struct {
+   int          errors;
+   IOR_point_t  write;
+   IOR_point_t  read;
 } IOR_results_t;
 
 /* define the queuing structure for the test parameters */
 typedef struct IOR_test_t {
    IOR_param_t        params;
-   IOR_results_t     *results; /* This is an array of reps times IOR_results_t */
+   IOR_results_t     *results;
    struct IOR_test_t *next;
 } IOR_test_t;
-
 
 IOR_test_t *CreateTest(IOR_param_t *init_params, int test_num);
 void AllocResults(IOR_test_t *test);

--- a/src/iordef.h
+++ b/src/iordef.h
@@ -96,7 +96,6 @@ enum OutputFormat_t{
 #define WRITECHECK         1
 #define READ               2
 #define READCHECK          3
-#define CHECK              4
 
 /* verbosity settings */
 #define VERBOSE_0          0


### PR DESCRIPTION
    Context: write and read results from the same iteration
    use the same length value in Bytes. When stonewalling is
    used the size variates depending on the performance of
    the access. This leads to wrong max bandwidths reported
    for writes as shown in the following example:
    
        write     10052      ...
        read      9910       ...
        write     10022      ...
        read      9880       ...
        write     10052      ...
        read      9894       ...
        Max Write: 9371.43 MiB/sec (9826.66 MB/sec)
        Max Read:  9910.48 MiB/sec (10391.89 MB/sec)
