### PR TITLE
Support old legacy name in backends

### DIFF
--- a/src/aiori-DUMMY.c
+++ b/src/aiori-DUMMY.c
@@ -136,6 +136,7 @@ static int DUMMY_stat (const char *path, struct stat *buf, IOR_param_t * param){
 
 ior_aiori_t dummy_aiori = {
   "DUMMY",
+  NULL,
   DUMMY_Create,
   DUMMY_Open,
   DUMMY_Xfer,

--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -98,6 +98,7 @@ static int HDF5_Access(const char *, int, IOR_param_t *);
 
 ior_aiori_t hdf5_aiori = {
         .name = "HDF5",
+        .name_legacy = NULL,
         .create = HDF5_Create,
         .open = HDF5_Open,
         .xfer = HDF5_Xfer,

--- a/src/aiori-HDFS.c
+++ b/src/aiori-HDFS.c
@@ -115,6 +115,7 @@ static IOR_offset_t HDFS_GetFileSize(IOR_param_t *, MPI_Comm, char *);
 
 ior_aiori_t hdfs_aiori = {
 	.name = "HDFS",
+	.name_legacy = NULL,
 	.create = HDFS_Create,
 	.open = HDFS_Open,
 	.xfer = HDFS_Xfer,
@@ -289,9 +290,9 @@ static void *HDFS_Create_Or_Open( char *testFileName, IOR_param_t *param, unsign
 	 * truncate each other's writes
 	 */
 
-	if (( param->openFlags & IOR_WRONLY ) && 
-			( !param->filePerProc )						&&	 
-			( rank != 0 )) { 
+	if (( param->openFlags & IOR_WRONLY ) &&
+			( !param->filePerProc )						&&
+			( rank != 0 )) {
 
 		MPI_CHECK(MPI_Barrier(testComm), "barrier error");
 	}
@@ -308,7 +309,7 @@ static void *HDFS_Create_Or_Open( char *testFileName, IOR_param_t *param, unsign
 					 param->transferSize,
 					 param->hdfs_replicas,
 					 param->hdfs_block_size);
-	}			 
+	}
 	hdfs_file = hdfsOpenFile( param->hdfs_fs,
 														testFileName,
 														fd_oflags,
@@ -323,12 +324,12 @@ static void *HDFS_Create_Or_Open( char *testFileName, IOR_param_t *param, unsign
 	 * For N-1 write, Rank 0 waits for the other ranks to open the file after it has.
 	 */
 
-	if (( param->openFlags & IOR_WRONLY ) && 
-			( !param->filePerProc )						&&	 
-			( rank == 0 )) { 
+	if (( param->openFlags & IOR_WRONLY ) &&
+			( !param->filePerProc )						&&
+			( rank == 0 )) {
 
 		MPI_CHECK(MPI_Barrier(testComm), "barrier error");
-	}		 
+	}
 
 	if (param->verbose >= VERBOSE_4) {
 		printf("<- HDFS_Create_Or_Open\n");
@@ -404,7 +405,7 @@ static IOR_offset_t HDFS_Xfer(int access, void *file, IOR_size_t * buffer,
 			}
 
 			if (param->verbose >= VERBOSE_4) {
-				printf("\thdfsWrite( 0x%llx, 0x%llx, 0x%llx, %lld)\n", 
+				printf("\thdfsWrite( 0x%llx, 0x%llx, 0x%llx, %lld)\n",
 							 hdfs_fs, hdfs_file, ptr, remaining ); /* DEBUGGING */
 			}
 			rc = hdfsWrite( hdfs_fs, hdfs_file, ptr, remaining );
@@ -426,7 +427,7 @@ static IOR_offset_t HDFS_Xfer(int access, void *file, IOR_size_t * buffer,
 			}
 
 			if (param->verbose >= VERBOSE_4) {
-				printf("\thdfsRead( 0x%llx, 0x%llx, 0x%llx, %lld)\n", 
+				printf("\thdfsRead( 0x%llx, 0x%llx, 0x%llx, %lld)\n",
 							 hdfs_fs, hdfs_file, ptr, remaining ); /* DEBUGGING */
 			}
 			rc = hdfsRead( hdfs_fs, hdfs_file, ptr, remaining );

--- a/src/aiori-IME.c
+++ b/src/aiori-IME.c
@@ -63,6 +63,7 @@ extern MPI_Comm testComm;
 
 ior_aiori_t ime_aiori = {
         .name          = "IME",
+        .name_legacy   = "IM",
         .create        = IME_Create,
         .open          = IME_Open,
         .xfer          = IME_Xfer,

--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -46,6 +46,7 @@ static void MPIIO_Fsync(void *, IOR_param_t *);
 
 ior_aiori_t mpiio_aiori = {
         .name = "MPIIO",
+        .name_legacy = NULL,
         .create = MPIIO_Create,
         .open = MPIIO_Open,
         .xfer = MPIIO_Xfer,

--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -62,6 +62,7 @@ static int NCMPI_Access(const char *, int, IOR_param_t *);
 
 ior_aiori_t ncmpi_aiori = {
         .name = "NCMPI",
+        .name_legacy = NULL,
         .create = NCMPI_Create,
         .open = NCMPI_Open,
         .xfer = NCMPI_Xfer,

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -77,6 +77,7 @@ static void POSIX_Fsync(void *, IOR_param_t *);
 
 ior_aiori_t posix_aiori = {
         .name = "POSIX",
+        .name_legacy = NULL,
         .create = POSIX_Create,
         .open = POSIX_Open,
         .xfer = POSIX_Xfer,

--- a/src/aiori-RADOS.c
+++ b/src/aiori-RADOS.c
@@ -67,6 +67,7 @@ static option_help * RADOS_options();
 /************************** D E C L A R A T I O N S ***************************/
 ior_aiori_t rados_aiori = {
         .name = "RADOS",
+        .name_legacy = NULL,
         .create = RADOS_Create,
         .open = RADOS_Open,
         .xfer = RADOS_Xfer,

--- a/src/aiori-S3.c
+++ b/src/aiori-S3.c
@@ -167,6 +167,7 @@ static void S3_finalize();
 //     N:N fails if "transfer-size" != "block-size" (because that requires "append")
 ior_aiori_t s3_aiori = {
 	.name = "S3",
+	.name_legacy = NULL,
 	.create = S3_Create,
 	.open = S3_Open,
 	.xfer = S3_Xfer,

--- a/src/aiori.h
+++ b/src/aiori.h
@@ -65,6 +65,7 @@ typedef struct ior_aiori_statfs {
 
 typedef struct ior_aiori {
         char *name;
+        char *name_legacy;
         void *(*create)(char *, IOR_param_t *);
         void *(*open)(char *, IOR_param_t *);
         IOR_offset_t (*xfer)(int, void *, IOR_size_t *,
@@ -101,7 +102,7 @@ void aiori_initialize(IOR_test_t * tests);
 void aiori_finalize(IOR_test_t * tests);
 const ior_aiori_t *aiori_select (const char *api);
 int aiori_count (void);
-void aiori_supported_apis(char * APIs);
+void aiori_supported_apis(char * APIs, char * APIs_legacy);
 const char *aiori_default (void);
 
 /* some generic POSIX-based backend calls */

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1303,7 +1303,8 @@ void print_help (void) {
     int j;
 
     char APIs[1024];
-    aiori_supported_apis(APIs);
+    char APIs_legacy[1024];
+    aiori_supported_apis(APIs, APIs_legacy);
     char apiStr[1024];
     sprintf(apiStr, "API for I/O [%s]", APIs);
 
@@ -2170,7 +2171,8 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     char * path = "./out";
     int randomize = 0;
     char APIs[1024];
-    aiori_supported_apis(APIs);
+    char APIs_legacy[1024];
+    aiori_supported_apis(APIs, APIs_legacy);
     char apiStr[1024];
     sprintf(apiStr, "API for I/O [%s]", APIs);
 

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -441,7 +441,8 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
     parameters = & initialTestParams;
 
     char APIs[1024];
-    aiori_supported_apis(APIs);
+    char APIs_legacy[1024];
+    aiori_supported_apis(APIs, APIs_legacy);
     char apiStr[1024];
     sprintf(apiStr, "API for I/O [%s]", APIs);
 


### PR DESCRIPTION
Context: Some backends may have used different names in
the past (like IME backend use to be IM). Legacy scripts
may break.

This patch adds a legacy name option in the aiori structure.
Both name and legacy name work to select the interface.
But the following warning is printed if the legacy name is used:

ior WARNING: [legacy name] backend is deprecated use [name] instead.