### PR TITLE
Moved HDF5 collective_md option into the backend.

### DIFF
--- a/doc/sphinx/userDoc/options.rst
+++ b/doc/sphinx/userDoc/options.rst
@@ -289,8 +289,9 @@ HDF5-ONLY
 
   * setAlignment         - HDF5 alignment in bytes (e.g.: 8, 4k, 2m, 1g) [1]
 
-  * collectiveMetadata   - enable HDF5 collective metadata (available since
-                           HDF5-1.10.0)
+HDF5-backend options
+^^^^^^^^^^^^^^^^^^^^
+  * -c | --collectiveMetadata   - enable HDF5 collective metadata (available since HDF5-1.10.0)
 
 MPIIO-, HDF5-, AND NCMPI-ONLY
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -93,6 +93,7 @@ static char* HDF5_GetVersion();
 static void HDF5_Fsync(void *, IOR_param_t *);
 static IOR_offset_t HDF5_GetFileSize(IOR_param_t *, MPI_Comm, char *);
 static int HDF5_Access(const char *, int, IOR_param_t *);
+static option_help * HDF5_get_options();
 
 /************************** D E C L A R A T I O N S ***************************/
 
@@ -112,6 +113,7 @@ ior_aiori_t hdf5_aiori = {
         .rmdir = aiori_posix_rmdir,
         .access = HDF5_Access,
         .stat = aiori_posix_stat,
+        .get_options = HDF5_get_options
 };
 
 static hid_t xferPropList;      /* xfer property list */
@@ -121,7 +123,26 @@ hid_t fileDataSpace;            /* file data space id */
 hid_t memDataSpace;             /* memory data space id */
 int newlyOpenedFile;            /* newly opened file */
 
+/************************** O P T I O N S *****************************/
+struct HDF5_options{
+  int collective_md;
+};
 /***************************** F U N C T I O N S ******************************/
+
+
+static struct HDF5_options o = {
+  .collective_md = 0
+};
+
+static option_help options [] = {
+      {'c', "collectiveMetadata",        "Use collectiveMetadata (available since HDF5-1.10.0)", OPTION_FLAG, 'd', & o.collective_md},
+      LAST_OPTION
+};
+
+static option_help * HDF5_get_options(){
+  return options;
+}
+
 
 /*
  * Create and open a file through the HDF5 interface.
@@ -230,7 +251,7 @@ static void *HDF5_Open(char *testFileName, IOR_param_t * param)
                    "cannot set alignment");
 
 #ifdef HAVE_H5PSET_ALL_COLL_METADATA_OPS
-        if (param->collective_md) {
+        if (o.collective_md) {
                 /* more scalable metadata */
 
                 HDF5_CHECK(H5Pset_all_coll_metadata_ops(accessPropList, 1),

--- a/src/ior.h
+++ b/src/ior.h
@@ -178,7 +178,6 @@ typedef struct
     char*       URI;                 /* "path" to target object */
     size_t      part_number;         /* multi-part upload increment (PER-RANK!) */
     char*       UploadId; /* key for multi-part-uploads */
-    int         collective_md;       /* use collective metatata optimization */
 
     /* RADOS variables */
     rados_t rados_cluster;           /* RADOS cluster handle */

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -302,8 +302,6 @@ void DecodeDirective(char *line, IOR_param_t *params)
                 params->numTasks = atoi(value);
         } else if (strcasecmp(option, "summaryalways") == 0) {
                 params->summary_every_test = atoi(value);
-        } else if (strcasecmp(option, "collectiveMetadata") == 0) {
-                params->collective_md = atoi(value);
         } else {
                 if (rank == 0)
                         fprintf(out_logfile, "Unrecognized parameter \"%s\"\n",


### PR DESCRIPTION
@roblatham00 @glennklockwood 
This is an example how the backend-specific options can be used to remove the dependencies to backends from the global options.

Example how to use:
./src/ior -a HDF5 -- --collectiveMetadata
or
./src/ior -a HDF5 -- -c 

Just to wrap up the discussion.

What is missing is that these options can be also controlled from inside an IOR script (right now only parsed once in the command line). That could be e.g.: backend_collectiveMetadata (for simplicity)
If nobody disagrees, I will move along at some point and make this happen. I would love to get rid of the plugin dependencies from ior.h