### PR TITLE
fixes #87

### DIFF
--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -365,6 +365,7 @@ IOR_test_t *ReadConfigScript(char *scriptName)
         int runflag = 0;
         char linebuf[MAX_STR];
         char empty[MAX_STR];
+        char *ptr;
         FILE *file;
         IOR_test_t *head = NULL;
         IOR_test_t *tail = NULL;
@@ -387,15 +388,22 @@ IOR_test_t *ReadConfigScript(char *scriptName)
 
         /* Iterate over a block of IOR commands */
         while (fgets(linebuf, MAX_STR, file) != NULL) {
+                /* skip over leading whitespace */
+                ptr = linebuf;
+                while (isspace(*ptr))
+                    ptr++;
+
                 /* skip empty lines */
-                if (sscanf(linebuf, "%s", empty) == -1)
+                if (sscanf(ptr, "%s", empty) == -1)
                         continue;
+
                 /* skip lines containing only comments */
-                if (sscanf(linebuf, " #%s", empty) == 1)
+                if (sscanf(ptr, " #%s", empty) == 1)
                         continue;
-                if (contains_only(linebuf, "ior stop")) {
+
+                if (contains_only(ptr, "ior stop")) {
                         break;
-                } else if (contains_only(linebuf, "run")) {
+                } else if (contains_only(ptr, "run")) {
                         if (runflag) {
                                 /* previous line was a "run" as well
                                    create duplicate test */
@@ -411,9 +419,9 @@ IOR_test_t *ReadConfigScript(char *scriptName)
                         tail->next = CreateTest(&tail->params, test_num++);
                         AllocResults(tail);
                         tail = tail->next;
-                        ParseLine(linebuf, &tail->params);
+                        ParseLine(ptr, &tail->params);
                 } else {
-                        ParseLine(linebuf, &tail->params);
+                        ParseLine(ptr, &tail->params);
                 }
         }
 

--- a/testing/basic-tests.sh
+++ b/testing/basic-tests.sh
@@ -23,4 +23,7 @@ IOR 2 -a POSIX -r    -z  -Z -Q 2        -F -k -e -i1 -m -t 100k -b 100k
 IOR 2 -a POSIX -r    -z  -Z -Q 3 -X  13 -F -k -e -i1 -m -t 100k -b 100k
 IOR 2 -a POSIX -w    -z  -Z -Q 1 -X -13 -F    -e -i1 -m -t 100k -b 100k
 
+
+IOR 2 -f "$ROOT/test_comments.ior"
+
 END

--- a/testing/test_comments.ior
+++ b/testing/test_comments.ior
@@ -1,0 +1,17 @@
+# test to ensure that leading whitespace is ignored
+IOR START
+api=posix
+writeFile =1
+    randomOffset=1
+reorderTasks=1
+  filePerProc=1
+		keepFile=1
+fsync=1
+	repetitions=1
+multiFile=1
+		# tab-prefixed comment
+transferSize=100k
+blockSize=100k
+    # space-prefixed comment
+run
+    ior stop


### PR DESCRIPTION
Leading whitespace is stripped from each line of the ior input file.  This allows indented comments to be treated as comments.  However it does NOT allow one to specify excessive whitespace inside of the `ior start` and `ior stop` magic phrases.

Also added a test to catch regressions in this functionality.

@roblatham00, is this a reasonable solution?