### PR TITLE
stop the segfault when an invalid api is specified in configfile

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1231,6 +1231,9 @@ static void TestIoSys(IOR_test_t *test)
 
         /* bind I/O calls to specific API */
         backend = aiori_select(params->api);
+        if (backend == NULL)
+                ERR_SIMPLE("unrecognized I/O API");
+
 
         /* show test setup */
         if (rank == 0 && verbose >= VERBOSE_0)


### PR DESCRIPTION
This stops the segfault that gets triggered when an invalid API is specified in the configfile (technically fixes #95), but it doesn't address the bigger bug indicated in #98.

Even if #98 isn't resolved in the short term, I'd like to put this into master so it can go into the 3.2 release.  I'd rather have a documented known issue than a segfault.