### PR TITLE
compile correctly with -std=c99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,17 @@ AM_INIT_AUTOMAKE([check-news dist-bzip2 gnu no-define foreign subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE
 
+# Check for system-specific stuff
+case "${host_os}" in
+  *linux*)
+    ;;
+  *darwin*)
+    CPPFLAGS="${CPPFLAGS} -D_DARWIN_C_SOURCE"
+    ;;
+  *)
+    ;;
+esac
+
 # Checks for programs
 
 # We can't do anything without a working MPI

--- a/src/aiori-DUMMY.c
+++ b/src/aiori-DUMMY.c
@@ -6,6 +6,8 @@
 #  include "config.h"
 #endif
 
+#define _XOPEN_SOURCE 700
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/aiori-MMAP.c
+++ b/src/aiori-MMAP.c
@@ -11,6 +11,8 @@
 #  include "config.h"
 #endif
 
+#define _XOPEN_SOURCE 700
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/aiori.c
+++ b/src/aiori.c
@@ -12,8 +12,19 @@
 *
 \******************************************************************************/
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#define _XOPEN_SOURCE 700
+
 #include <assert.h>
 #include <stdbool.h>
+
+#if defined(HAVE_STRINGS_H)
+#include <strings.h>
+#endif
+
 #include "aiori.h"
 
 #if defined(HAVE_SYS_STATVFS_H)

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -28,6 +28,7 @@
  *   $Date: 2013/11/27 17:05:31 $
  *   $Author: brettkettering $
  */
+#define _XOPEN_SOURCE 700
 
 #include <limits.h>
 #include <math.h>
@@ -59,6 +60,11 @@
 
 #include <fcntl.h>
 #include <string.h>
+
+#if HAVE_STRINGS_H
+#include <strings.h>
+#endif
+
 #include <unistd.h>
 #include <dirent.h>
 #include <errno.h>
@@ -1616,7 +1622,7 @@ void valid_tests() {
         FAIL("-c not compatible with -B");
     }
 
-    if ( strcasecmp(backend_name, "POSIX") != 0 && strcasecmp(backend_name, "DUMMY") != 0) {
+    if (strcasecmp(backend_name, "POSIX") != 0 && strcasecmp(backend_name, "DUMMY") != 0) {
       FAIL("-a only supported interface is POSIX (and DUMMY) right now!");
     }
 

--- a/src/option.c
+++ b/src/option.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <assert.h>
 #include <stdlib.h>

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -16,11 +16,16 @@
 #include "config.h"
 #endif
 
+#define _XOPEN_SOURCE 700
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
 
+#if defined(HAVE_STRINGS_H)
+#include <strings.h>
+#endif
 
 #include "utilities.h"
 #include "ior.h"

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -5,7 +5,7 @@
 #
 
 # These options will be passed directly to the autoconf configure script
-CONFIGURE_OPTS="${CONFIGURE_OPTS:-""}"
+CONFIGURE_OPTS="${CONFIGURE_OPTS:-"CFLAGS=-std=c99 --disable-silent-rules"}"
 
 BASE_DIR="$(cd "${0%/*}" && pwd)"
 if [ -z "$BASE_DIR" -o ! -d "$BASE_DIR" ]; then


### PR DESCRIPTION
This patch enables correct compilation on both MacOS and Linux using only POSIX.1-2008-compliant C with XSI extensions.  It also changes the travis build to explicitly use `-std=c99` to catch noncompliant patches going forward.

This does _not_ require a user compile with strict POSIX conformance though, and the general expectation is that most users will continue to build with various GNUisms enabled by default (and in fact, this is required to compile with `--with-lustre`).  The intent here is just to curb any creeping dependence on a specific libc or compiler.

resolves #93