### PR TITLE
IME: add support of mkdir/rmdir into the IME backend

### DIFF
--- a/src/aiori-IME.c
+++ b/src/aiori-IME.c
@@ -272,10 +272,10 @@ static char *IME_GetVersion()
 /*
  * XXX: statfs call is currently not exposed by IME native interface.
  */
-static int IME_StatFS(const char *oid, ior_aiori_statfs_t *stat_buf,
+static int IME_StatFS(const char *path, ior_aiori_statfs_t *stat_buf,
                       IOR_param_t *param)
 {
-        (void)oid;
+        (void)path;
         (void)stat_buf;
         (void)param;
 
@@ -283,29 +283,33 @@ static int IME_StatFS(const char *oid, ior_aiori_statfs_t *stat_buf,
         return -1;
 }
 
-/*
- * XXX: mkdir call is currently not exposed by IME native interface.
- */
-static int IME_MkDir(const char *oid, mode_t mode, IOR_param_t *param)
+static int IME_MkDir(const char *path, mode_t mode, IOR_param_t *param)
 {
-        (void)oid;
-        (void)mode;
         (void)param;
 
-        WARN("mkdir is currently not supported in IME backend!");
+#if (IME_NATIVE_API_VERSION >= 130)
+        return ime_native_mkdir(path, mode);
+#else
+        (void)path;
+        (void)mode;
+
+        WARN("mkdir not supported in IME backend!");
         return -1;
+#endif
 }
 
-/*
- * XXX: rmdir call is curretly not exposed by IME native interface.
- */
-static int IME_RmDir(const char *oid, IOR_param_t *param)
+static int IME_RmDir(const char *path, IOR_param_t *param)
 {
-        (void)oid;
         (void)param;
 
-        WARN("rmdir is currently not supported in IME backend!");
+#if (IME_NATIVE_API_VERSION >= 130)
+        return ime_native_rmdir(path);
+#else
+        (void)path;
+
+        WARN("rmdir not supported in IME backend!");
         return -1;
+#endif
 }
 
 /*

--- a/src/ior.c
+++ b/src/ior.c
@@ -823,14 +823,15 @@ static char *PrependDir(IOR_param_t * test, char *rootDir)
         sprintf(dir, "%s%d", dir, (rank + rankOffset) % test->numTasks);
 
         /* dir doesn't exist, so create */
-        if (access(dir, F_OK) != 0) {
-                if (mkdir(dir, S_IRWXU) < 0) {
+        if (backend->access(dir, F_OK, test) != 0) {
+                if (backend->mkdir(dir, S_IRWXU, test) < 0) {
                         ERR("cannot create directory");
                 }
 
                 /* check if correct permissions */
-        } else if (access(dir, R_OK) != 0 || access(dir, W_OK) != 0 ||
-                   access(dir, X_OK) != 0) {
+        } else if (backend->access(dir, R_OK, test) != 0 ||
+                   backend->access(dir, W_OK, test) != 0 ||
+                   backend->access(dir, X_OK, test) != 0) {
                 ERR("invalid directory permissions");
         }
 


### PR DESCRIPTION
This patch adds the support of `rmdir/mkdir` syscalls into the IME backend (feature supported starting from IME 1.3).
In addition, this patch fixes an issue in function PrependDir(), which bypasses the backend's implementation of `rmdir/mkdir`.