### PR TITLE
lustre: fix checks for lustre_user.h header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ esac
 
 # We can't do anything without a working MPI
 AX_PROG_CC_MPI(,,[
-    AC_MSG_FAILURE([MPI compiler requested, but couldn't use MPI.])
+    AC_MSG_FAILURE([MPI compiler requested, but could not use MPI.])
 ])
 
 AC_PROG_RANLIB
@@ -85,7 +85,9 @@ AC_ARG_WITH([lustre],
         [], [with_lustre=check])
 AS_IF([test "x$with_lustre" != xno], [
         AC_CHECK_HEADERS([linux/lustre/lustre_user.h lustre/lustre_user.h], break, [
-                if test "x$with_lustre" != xcheck; then
+                if test "x$with_lustre" != xcheck -a \
+                        "x$ac_cv_header_linux_lustre_lustre_user_h" = "xno" -a \
+                        "x$ac_cv_header_lustre_lustre_user_h" = "xno" ; then
                         AC_MSG_FAILURE([--with-lustre was given, <lustre/lustre_user.h> not found])
                 fi
         ])

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -32,11 +32,10 @@
 #include <assert.h>
 
 
-#ifdef HAVE_LUSTRE_LUSTRE_USER_H
-#  include <lustre/lustre_user.h>
-#endif
 #ifdef HAVE_LINUX_LUSTRE_LUSTRE_USER_H
 #  include <linux/lustre/lustre_user.h>
+#elif defined(HAVE_LUSTRE_LUSTRE_USER_H)
+#  include <lustre/lustre_user.h>
 #endif
 #ifdef HAVE_GPFS_H
 #  include <gpfs.h>
@@ -282,6 +281,12 @@ void *POSIX_Create(char *testFileName, IOR_param_t * param)
           return 0;
 
 #ifdef HAVE_LUSTRE_LUSTRE_USER_H
+/* Add a #define for FASYNC if not available, as it forms part of
+ * the Lustre O_LOV_DELAY_CREATE definition. */
+#ifndef FASYNC
+#define FASYNC          00020000   /* fcntl, for BSD compatibility */
+#endif
+
         if (param->lustre_set_striping) {
                 /* In the single-shared-file case, task 0 has to creat the
                    file with the Lustre striping options before any other processes
@@ -302,7 +307,8 @@ void *POSIX_Create(char *testFileName, IOR_param_t * param)
                         opts.lmm_stripe_count = param->lustre_stripe_count;
 
                         /* File needs to be opened O_EXCL because we cannot set
-                           Lustre striping information on a pre-existing file. */
+                         * Lustre striping information on a pre-existing file.*/
+
                         fd_oflag |=
                             O_CREAT | O_EXCL | O_RDWR | O_LOV_DELAY_CREATE;
                         *fd = open64(testFileName, fd_oflag, 0664);


### PR DESCRIPTION
Fix the configure check if --with-lustre is specified, but
the linux/lustre/lustre_user.h header is not present.  Only
one of the headers needs to be included if both are found.

In some cases, FASYNC is not defined, but forms part of the
O_LOV_DELAY_CREATE value, add a #define in that case.

Fix quoting in MPI check to avoid upsetting syntax highlighting.

Fixes #115.

Fixes: cb88c4c19a831d94b864c49a162e2635730540e5
Signed-off-by: Andreas Dilger <adilger@dilger.ca>