### PR TITLE
Fix segfault with option memoryPerNode

### DIFF
--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -537,7 +537,7 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
           }
         }
         if (memoryPerNode){
-          initialTestParams.memoryPerNode = NodeMemoryStringToBytes(optarg);
+          initialTestParams.memoryPerNode = NodeMemoryStringToBytes(memoryPerNode);
         }
 
         const ior_aiori_t * backend = aiori_select(initialTestParams.api);


### PR DESCRIPTION
optarg contains a NULL address, which causes a segfault in
NodeMemoryStringToBytes().