### PR TITLE
Adding support for NetCDF-4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ src/*.o
 src/*.i
 src/*.s
 src/*.a
+src/test-suite.log
+src/testlib.log
+src/testlib.trs
 src/ior
 src/mdtest
 src/testlib

--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,15 @@ src/stamp-h1
 NOTES.txt
 autom4te.cache
 contrib/cbif.o
+contrib/cbif
 src/*.o
 src/*.i
 src/*.s
+src/*.a
 src/ior
+src/mdtest
+src/testlib
+src/test/*.o
 
 doc/doxygen/build
 doc/sphinx/_*/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ src/config.h
 src/config.h.in
 src/stamp-h1
 *~
+.idea/
 NOTES.txt
 autom4te.cache
 contrib/cbif.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,15 @@ install:
     - sudo apt-get install -y openmpi-bin libopenmpi-dev
     # Install HDF5
     - sudo apt-get install -y hdf5-tools libhdf5-mpi-dev
+    # Install NetCDF4
+    - sudo apt-get install -y libnetcdf-mpi-dev
     # Install Lustre
     # TODO: As far as a i can see it needs to be compiled form source with kernel
     # module as there is no package.
     # It seams that there are .debs releases for lustre, but its only for 16.04
     # So need to wait till travis is updated.
     # https://downloads.hpdd.intel.com/public/lustre/lustre-2.10.3/
-    # Install  Parallel netcdf
+    # Install Parallel netcdf
     # TODO: Not in repos for 14.04 trustz but comes 16.04 xenial
     #- sudo apt-get install -y libpnetcdf-dev pnetcdf-bin
     # Install HDFS
@@ -28,4 +30,4 @@ install:
     # aiori-S3.c to achive this.
     # GPFS
     # NOTE: Think GPFS need a license and is therefore not testable with travis.
-script: ./travis-build.sh && CONFIGURE_OPTS="--with-hdf5" ./travis-test.sh
+script: ./travis-build.sh && CONFIGURE_OPTS="--with-hdf5 --with-nc4" ./travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ install:
     - sudo apt-get install -y openmpi-bin libopenmpi-dev
     # Install HDF5
     - sudo apt-get install -y hdf5-tools libhdf5-mpi-dev
-    # Install NetCDF4
-    - sudo apt-get install -y libnetcdf-mpi-dev
     # Install Lustre
     # TODO: As far as a i can see it needs to be compiled form source with kernel
     # module as there is no package.
@@ -30,4 +28,4 @@ install:
     # aiori-S3.c to achive this.
     # GPFS
     # NOTE: Think GPFS need a license and is therefore not testable with travis.
-script: ./travis-build.sh && CONFIGURE_OPTS="--with-hdf5 --with-nc4" ./travis-test.sh
+script: ./travis-build.sh && CONFIGURE_OPTS="--with-hdf5" ./travis-test.sh

--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,17 @@ AM_COND_IF([USE_NCMPI_AIORI],[
         AC_DEFINE([USE_NCMPI_AIORI], [], [Build NCMPI backend AIORI])
 ])
 
+# NC (netcdf-4 with parallel support) support
+AC_ARG_WITH([nc4],
+        [AS_HELP_STRING([--with-nc4],
+           [support IO with NC4 backend @<:@default=no@:>@])],
+        [],
+        [with_nc4=no])
+AM_CONDITIONAL([USE_NC4_AIORI], [test x$with_nc4 = xyes])
+AM_COND_IF([USE_NC4_AIORI],[
+        AC_DEFINE([USE_NC4_AIORI], [], [Build NC4 backend AIORI])
+])
+
 # MMAP IO support
 AC_ARG_WITH([mmap],
         [AS_HELP_STRING([--with-mmap],

--- a/configure.ac
+++ b/configure.ac
@@ -152,7 +152,7 @@ AM_COND_IF([USE_NCMPI_AIORI],[
         AC_DEFINE([USE_NCMPI_AIORI], [], [Build NCMPI backend AIORI])
 ])
 
-# NC (netcdf-4 with parallel support) support
+# NC4 (netcdf-4 with parallel support) support
 AC_ARG_WITH([nc4],
         [AS_HELP_STRING([--with-nc4],
            [support IO with NC4 backend @<:@default=no@:>@])],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,6 +57,11 @@ extraSOURCES += aiori-NCMPI.c
 extraLDADD   += -lpnetcdf
 endif
 
+if USE_NC4_AIORI
+extraSOURCES += aiori-NC4.c
+extraLDADD   += -lnetcdf
+endif
+
 if USE_MMAP_AIORI
 extraSOURCES += aiori-MMAP.c
 endif

--- a/src/aiori-NC4.c
+++ b/src/aiori-NC4.c
@@ -1,0 +1,358 @@
+/* -*- mode: c; c-basic-offset: 8; indent-tabs-mode: nil; -*-
+ * vim:expandtab:shiftwidth=8:tabstop=8:
+ */
+/******************************************************************************\
+*                                                                              *
+*        Copyright (c) 2003, The Regents of the University of California       *
+*      See the file COPYRIGHT for a complete copyright notice and license.     *
+*                                                                              *
+********************************************************************************
+*
+* Implement abstract I/O interface for NetCDF-4 with parallel support (NC4).
+*
+\******************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <netcdf.h>
+#include <netcdf_par.h>
+
+#include "ior.h"
+#include "iordef.h"
+#include "aiori.h"
+#include "utilities.h"
+
+#define NUM_DIMS 3              /* number of dimensions to data set */
+
+/*
+ * NC4_CHECK will display a custom error message and then exit the program
+ */
+#define NC4_CHECK(NC4_RETURN, MSG) do {                              \
+                                                                         \
+    if (NC4_RETURN < 0) {                                              \
+        fprintf(stdout, "** error **\n");                                \
+        fprintf(stdout, "ERROR in %s (line %d): %s.\n",                  \
+                __FILE__, __LINE__, MSG);                                \
+        fprintf(stdout, "ERROR: %s.\n", nc_strerror(NC4_RETURN));   \
+        fprintf(stdout, "** exiting **\n");                              \
+        exit(-1);                                                        \
+    }                                                                    \
+} while(0)
+
+/**************************** P R O T O T Y P E S *****************************/
+
+static int GetFileMode(IOR_param_t *);
+
+static char *GetNamedMessage(char * message, char * name);
+
+static void *NC4_Create(char *, IOR_param_t *);
+
+static void *NC4_Open(char *, IOR_param_t *);
+
+static IOR_offset_t NC4_Xfer(int, void *, IOR_size_t *,
+                             IOR_offset_t, IOR_param_t *);
+
+static void NC4_Close(void *, IOR_param_t *);
+
+static void NC4_Delete(char *, IOR_param_t *);
+
+static char *NC4_GetVersion();
+
+static void NC4_Fsync(void *, IOR_param_t *);
+
+static IOR_offset_t NC4_GetFileSize(IOR_param_t *, MPI_Comm, char *);
+
+static int NC4_Access(const char *, int, IOR_param_t *);
+
+/************************** D E C L A R A T I O N S ***************************/
+
+ior_aiori_t nc4_aiori = {
+        .name = "NC4",
+        .name_legacy = NULL,
+        .create = NC4_Create,
+        .open = NC4_Open,
+        .xfer = NC4_Xfer,
+        .close = NC4_Close,
+        .delete = NC4_Delete,
+        .get_version = NC4_GetVersion,
+        .fsync = NC4_Fsync,
+        .get_file_size = NC4_GetFileSize,
+        .statfs = aiori_posix_statfs,
+        .mkdir = aiori_posix_mkdir,
+        .rmdir = aiori_posix_rmdir,
+        .access = NC4_Access,
+        .stat = aiori_posix_stat,
+};
+
+/***************************** F U N C T I O N S ******************************/
+
+/*
+ * Create and open a file through the NC4 interface.
+ */
+static void *NC4_Create(char *testFileName, IOR_param_t *param) {
+    int *fd;
+    int fd_mode;
+    MPI_Info mpiHints = MPI_INFO_NULL;
+
+    SetHints(&mpiHints, param->hintsFileName);
+    if (rank == 0 && param->showHints) {
+        fprintf(stdout, "\nhints passed to nc_create_par() {\n");
+        ShowHints(&mpiHints);
+        fprintf(stdout, "}\n");
+    }
+
+    fd = (int *) malloc(sizeof(int));
+    if (fd == NULL)
+        ERR("malloc() failed");
+
+    fd_mode = GetFileMode(param);
+    NC4_CHECK(nc_create_par(testFileName, fd_mode, testComm, mpiHints, fd),
+              "cannot create file");
+
+    return (fd);
+}
+
+/*
+ * Open a file through the NC4 interface.
+ */
+static void *NC4_Open(char *testFileName, IOR_param_t *param) {
+    int *fd;
+    int fd_mode;
+    MPI_Info mpiHints = MPI_INFO_NULL;
+
+    SetHints(&mpiHints, param->hintsFileName);
+    if (rank == 0 && param->showHints) {
+        fprintf(stdout, "\nhints passed to nc_open_par() {\n");
+        ShowHints(&mpiHints);
+        fprintf(stdout, "}\n");
+    }
+
+    fd = (int *) malloc(sizeof(int));
+    if (fd == NULL)
+        ERR("malloc() failed");
+
+    fd_mode = GetFileMode(param);
+    NC4_CHECK(nc_open_par(testFileName, fd_mode, testComm, mpiHints, fd),
+              "cannot open file");
+
+    return (fd);
+}
+
+/*
+ * Write or read access to file using the NC4 interface.
+ */
+static IOR_offset_t NC4_Xfer(int access, void *fd, IOR_size_t *buffer,
+                             IOR_offset_t length, IOR_param_t *param) {
+    signed char *bufferPtr = (signed char *) buffer;
+    static int firstReadCheck = FALSE, startDataSet;
+    int var_id, dim_id[NUM_DIMS];
+    size_t bufSize[NUM_DIMS], offset[NUM_DIMS], chunk_sizes[NUM_DIMS];
+    IOR_offset_t segmentPosition;
+    int segmentNum, transferNum;
+
+    if (length != param->transferSize) {
+        char errMsg[256];
+        sprintf(errMsg, "length(%lld) != param->transferSize(%lld)\n",
+                length, param->transferSize);
+        NC4_CHECK(-1, errMsg);
+    }
+
+    if (param->filePerProc == TRUE) {
+        segmentPosition = (IOR_offset_t) 0;
+    } else {
+        segmentPosition =
+                (IOR_offset_t) ((rank + rankOffset) % param->numTasks)
+                * param->blockSize;
+    }
+    if ((int) (param->offset - segmentPosition) == 0) {
+        startDataSet = TRUE;
+        if (access == READCHECK) {
+            if (firstReadCheck == TRUE) {
+                firstReadCheck = FALSE;
+            } else {
+                firstReadCheck = TRUE;
+            }
+        }
+    }
+
+    if (startDataSet == TRUE && (access != READCHECK || firstReadCheck == TRUE)) {
+        char * message;
+        char * name;
+
+        if (access == WRITE) {
+            int numSegmentsTimesN = param->segmentCount * param->numTasks;
+
+            message = "cannot define dataset dimension";
+            name = "segments_times_np";
+            NC4_CHECK(nc_def_dim(*(int *) fd, name, numSegmentsTimesN, &dim_id[0]),
+                    GetNamedMessage(message, name));
+
+            int numTransfers =
+                    param->blockSize / param->transferSize;
+
+            name = "number_of_transfers";
+            NC4_CHECK(nc_def_dim(*(int *) fd, name, numTransfers, &dim_id[1]),
+                    GetNamedMessage(message, name));
+
+            name = "transfer_size";
+            NC4_CHECK(nc_def_dim(*(int *) fd, name, param->transferSize, &dim_id[2]),
+                    GetNamedMessage(message, name));
+
+            message = "cannot define dataset variable";
+            name = "data_var";
+            NC4_CHECK(nc_def_var(*(int *) fd, name, NC_BYTE, NUM_DIMS, dim_id, &var_id),
+                    GetNamedMessage(message, name));
+
+            message = "cannot define chunksizes for dataset variable";
+            name = "data_var";
+            chunk_sizes[0] = 1;
+            chunk_sizes[1] = 1;
+            chunk_sizes[2] = param->transferSize;
+            NC4_CHECK(nc_def_var_chunking(*(int *) fd, var_id, NC_CHUNKED, &chunk_sizes),
+                      GetNamedMessage(message, name));
+
+            NC4_CHECK(nc_enddef(*(int *) fd), "cannot close dataset define mode");
+
+        } else {
+            message = "cannot retrieve dataset variable";
+            name = "data_var";
+            NC4_CHECK(nc_inq_varid(*(int *) fd, name, &var_id),
+                    GetNamedMessage(message, name));
+        }
+
+        if (param->collective) {
+            NC4_CHECK(nc_var_par_access(*(int *) fd, var_id, NC_COLLECTIVE),
+                    "cannot enable collective data mode");
+        }
+
+        param->var_id = var_id;
+        startDataSet = FALSE;
+    }
+
+    var_id = param->var_id;
+
+    segmentNum = param->offset / (param->numTasks * param->blockSize);
+
+    transferNum = param->offset % param->blockSize / param->transferSize;
+
+    bufSize[0] = 1;
+    bufSize[1] = 1;
+    bufSize[2] = param->transferSize;
+
+    offset[0] = segmentNum * numTasksWorld + rank;
+    offset[1] = transferNum;
+    offset[2] = 0;
+
+    if (access == WRITE) {
+        NC4_CHECK(nc_put_vara_schar(*(int *) fd, var_id, offset, bufSize, bufferPtr),
+                "cannot write to dataset");
+    } else {
+        NC4_CHECK(nc_get_vara_schar(*(int *) fd, var_id, offset, bufSize, bufferPtr),
+                "cannot read from dataset");
+    }
+
+    return (length);
+}
+
+/*
+ * Perform sync().
+ */
+static void NC4_Fsync(void *fd, IOR_param_t *param) {
+    NC4_CHECK(nc_sync(*(int *) fd), "cannot sync dataset to disk");
+}
+
+/*
+ * Close a file through the NC4 interface.
+ */
+static void NC4_Close(void *fd, IOR_param_t *param) {
+//    if (param->collective) {
+//        NC4_CHECK(nc_var_par_access(*(int *) fd, var_id, NC_INDEPENDENT),
+//                  "cannot disable collective data mode");
+//    }
+    NC4_CHECK(nc_close(*(int *) fd), "cannot close file");
+    free(fd);
+}
+
+/*
+ * Delete a file through the NC4 interface.
+ */
+static void NC4_Delete(char *testFileName, IOR_param_t *param) {
+    return (MPIIO_Delete(testFileName, param));
+}
+
+/*
+ * Determine api version.
+ */
+static char *NC4_GetVersion() {
+    return (char *) nc_inq_libvers();
+}
+
+/*
+ * Use MPIIO call to get file size.
+ */
+static IOR_offset_t NC4_GetFileSize(IOR_param_t *test, MPI_Comm testComm, char *testFileName) {
+    return (MPIIO_GetFileSize(test, testComm, testFileName));
+}
+
+/*
+ * Use MPIIO call to check for access.
+ */
+static int NC4_Access(const char *path, int mode, IOR_param_t *param) {
+    return (MPIIO_Access(path, mode, param));
+}
+
+/*
+ * Return the correct file mode for NC4.
+ */
+static int GetFileMode(IOR_param_t *param) {
+    int fd_mode = 0;
+
+    /* set IOR file flags to NC4 flags */
+    if (param->openFlags & IOR_RDONLY) {
+        fd_mode |= NC_NOWRITE;
+    }
+    if (param->openFlags & IOR_WRONLY) {
+        fprintf(stdout, "File write only not implemented in NC4\n");
+    }
+    if (param->openFlags & IOR_RDWR) {
+        fd_mode |= NC_WRITE;
+    }
+    if (param->openFlags & IOR_APPEND) {
+        fprintf(stdout, "File append not implemented in NC4\n");
+    }
+    if (param->openFlags & IOR_CREAT) {
+        fd_mode |= NC_CLOBBER;
+    }
+    if (param->openFlags & IOR_EXCL) {
+        fprintf(stdout, "Exclusive access not implemented in NC4\n");
+    }
+    if (param->openFlags & IOR_TRUNC) {
+        fprintf(stdout, "File truncation not implemented in NC4\n");
+    }
+    if (param->openFlags & IOR_DIRECT) {
+        fprintf(stdout, "O_DIRECT not implemented in NC4\n");
+    }
+
+//    fd_mode |= NC_64BIT_OFFSET;
+//    fd_mode |= NC_64BIT_DATA;
+    fd_mode |= NC_NETCDF4;
+
+    return (fd_mode);
+}
+
+/* Construct a message referencing a specific name */
+static char * GetNamedMessage(char * message, char * name) {
+    char * msg;
+    strcpy(msg, message);
+    strcat(msg, " (");
+    strcat(msg, name);
+    strcat(msg, ")");
+
+    return (msg);
+}

--- a/src/aiori-NC4.c
+++ b/src/aiori-NC4.c
@@ -191,23 +191,22 @@ static IOR_offset_t NC4_Xfer(int access, void *fd, IOR_size_t *buffer,
             message = "cannot define dataset dimension";
             name = "segments_times_np";
             NC4_CHECK(nc_def_dim(*(int *) fd, name, numSegmentsTimesN, &dim_id[0]),
-                    GetNamedMessage(message, name));
+                      GetNamedMessage(message, name));
 
-            int numTransfers =
-                    param->blockSize / param->transferSize;
+            int numTransfers = param->blockSize / param->transferSize;
 
             name = "number_of_transfers";
             NC4_CHECK(nc_def_dim(*(int *) fd, name, numTransfers, &dim_id[1]),
-                    GetNamedMessage(message, name));
+                      GetNamedMessage(message, name));
 
             name = "transfer_size";
             NC4_CHECK(nc_def_dim(*(int *) fd, name, param->transferSize, &dim_id[2]),
-                    GetNamedMessage(message, name));
+                      GetNamedMessage(message, name));
 
             message = "cannot define dataset variable";
             name = "data_var";
             NC4_CHECK(nc_def_var(*(int *) fd, name, NC_BYTE, NUM_DIMS, dim_id, &var_id),
-                    GetNamedMessage(message, name));
+                      GetNamedMessage(message, name));
 
             message = "cannot define chunksizes for dataset variable";
             name = "data_var";
@@ -223,12 +222,12 @@ static IOR_offset_t NC4_Xfer(int access, void *fd, IOR_size_t *buffer,
             message = "cannot retrieve dataset variable";
             name = "data_var";
             NC4_CHECK(nc_inq_varid(*(int *) fd, name, &var_id),
-                    GetNamedMessage(message, name));
+                      GetNamedMessage(message, name));
         }
 
         if (param->collective) {
             NC4_CHECK(nc_var_par_access(*(int *) fd, var_id, NC_COLLECTIVE),
-                    "cannot enable collective data mode");
+                      "cannot enable collective data mode");
         }
 
         param->var_id = var_id;
@@ -251,10 +250,10 @@ static IOR_offset_t NC4_Xfer(int access, void *fd, IOR_size_t *buffer,
 
     if (access == WRITE) {
         NC4_CHECK(nc_put_vara_schar(*(int *) fd, var_id, offset, bufSize, bufferPtr),
-                "cannot write to dataset");
+                  "cannot write to dataset");
     } else {
         NC4_CHECK(nc_get_vara_schar(*(int *) fd, var_id, offset, bufSize, bufferPtr),
-                "cannot read from dataset");
+                  "cannot read from dataset");
     }
 
     return (length);
@@ -339,8 +338,6 @@ static int GetFileMode(IOR_param_t *param) {
         fprintf(stdout, "O_DIRECT not implemented in NC4\n");
     }
 
-//    fd_mode |= NC_64BIT_OFFSET;
-//    fd_mode |= NC_64BIT_DATA;
     fd_mode |= NC_NETCDF4;
 
     return (fd_mode);

--- a/src/aiori.c
+++ b/src/aiori.c
@@ -58,6 +58,9 @@ ior_aiori_t *available_aiori[] = {
 #ifdef USE_NCMPI_AIORI
         &ncmpi_aiori,
 #endif
+#ifdef USE_NC4_AIORI
+        &nc4_aiori,
+#endif
 #ifdef USE_MMAP_AIORI
         &mmap_aiori,
 #endif

--- a/src/aiori.h
+++ b/src/aiori.h
@@ -98,6 +98,7 @@ extern ior_aiori_t hdfs_aiori;
 extern ior_aiori_t ime_aiori;
 extern ior_aiori_t mpiio_aiori;
 extern ior_aiori_t ncmpi_aiori;
+extern ior_aiori_t nc4_aiori;
 extern ior_aiori_t posix_aiori;
 extern ior_aiori_t mmap_aiori;
 extern ior_aiori_t s3_aiori;

--- a/src/ior.c
+++ b/src/ior.c
@@ -295,7 +295,7 @@ static void CheckFileSize(IOR_test_t *test, IOR_offset_t dataMoved, int rep,
                                 1, MPI_LONG_LONG_INT, MPI_SUM, testComm),
                   "cannot total data moved");
 
-        if (strcasecmp(params->api, "HDF5") != 0 && strcasecmp(params->api, "NCMPI") != 0) {
+        if (strcasecmp(params->api, "HDF5") != 0 && strcasecmp(params->api, "NCMPI") != 0 && strcasecmp(params->api, "NC4") != 0) {
                 if (verbose >= VERBOSE_0 && rank == 0) {
                         if ((params->expectedAggFileSize
                              != point->aggFileSizeFromXfer)
@@ -1583,6 +1583,10 @@ static void ValidateTests(IOR_param_t * test)
             && (test->blockSize < sizeof(IOR_size_t)
                 || test->transferSize < sizeof(IOR_size_t)))
                 ERR("block/transfer size may not be smaller than IOR_size_t for NCMPI");
+        if ((strcasecmp(test->api, "NC") == 0)
+            && (test->blockSize < sizeof(IOR_size_t)
+                || test->transferSize < sizeof(IOR_size_t)))
+            ERR("block/transfer size may not be smaller than IOR_size_t for NC");
         if ((test->useFileView == TRUE)
             && (sizeof(MPI_Aint) < 8)   /* used for 64-bit datatypes */
             &&((test->numTasks * test->blockSize) >
@@ -1656,6 +1660,8 @@ static void ValidateTests(IOR_param_t * test)
                 ERR("random offset not available with HDF5");
         if ((strcasecmp(test->api, "NCMPI") == 0) && test->randomOffset)
                 ERR("random offset not available with NCMPI");
+        if ((strcasecmp(test->api, "NC") == 0) && test->randomOffset)
+            ERR("random offset not available with NC");
         if ((strcasecmp(test->api, "HDF5") != 0) && test->individualDataSets)
                 WARN_RESET("individual datasets only available in HDF5",
                            test, &defaults, individualDataSets);
@@ -1664,6 +1670,8 @@ static void ValidateTests(IOR_param_t * test)
                            test, &defaults, individualDataSets);
         if ((strcasecmp(test->api, "NCMPI") == 0) && test->filePerProc)
                 ERR("file-per-proc not available in current NCMPI");
+        if ((strcasecmp(test->api, "NC") == 0) && test->filePerProc)
+            ERR("file-per-proc not available in current NC");
         if (test->noFill) {
                 if (strcasecmp(test->api, "HDF5") != 0) {
                         ERR("'no fill' option only available in HDF5");

--- a/src/ior.c
+++ b/src/ior.c
@@ -1583,10 +1583,10 @@ static void ValidateTests(IOR_param_t * test)
             && (test->blockSize < sizeof(IOR_size_t)
                 || test->transferSize < sizeof(IOR_size_t)))
                 ERR("block/transfer size may not be smaller than IOR_size_t for NCMPI");
-        if ((strcasecmp(test->api, "NC") == 0)
+        if ((strcasecmp(test->api, "NC4") == 0)
             && (test->blockSize < sizeof(IOR_size_t)
                 || test->transferSize < sizeof(IOR_size_t)))
-            ERR("block/transfer size may not be smaller than IOR_size_t for NC");
+            ERR("block/transfer size may not be smaller than IOR_size_t for NC4");
         if ((test->useFileView == TRUE)
             && (sizeof(MPI_Aint) < 8)   /* used for 64-bit datatypes */
             &&((test->numTasks * test->blockSize) >
@@ -1660,8 +1660,8 @@ static void ValidateTests(IOR_param_t * test)
                 ERR("random offset not available with HDF5");
         if ((strcasecmp(test->api, "NCMPI") == 0) && test->randomOffset)
                 ERR("random offset not available with NCMPI");
-        if ((strcasecmp(test->api, "NC") == 0) && test->randomOffset)
-            ERR("random offset not available with NC");
+        if ((strcasecmp(test->api, "NC4") == 0) && test->randomOffset)
+            ERR("random offset not available with NC4");
         if ((strcasecmp(test->api, "HDF5") != 0) && test->individualDataSets)
                 WARN_RESET("individual datasets only available in HDF5",
                            test, &defaults, individualDataSets);
@@ -1670,8 +1670,8 @@ static void ValidateTests(IOR_param_t * test)
                            test, &defaults, individualDataSets);
         if ((strcasecmp(test->api, "NCMPI") == 0) && test->filePerProc)
                 ERR("file-per-proc not available in current NCMPI");
-        if ((strcasecmp(test->api, "NC") == 0) && test->filePerProc)
-            ERR("file-per-proc not available in current NC");
+        if ((strcasecmp(test->api, "NC4") == 0) && test->filePerProc)
+            ERR("file-per-proc not available in current NC4");
         if (test->noFill) {
                 if (strcasecmp(test->api, "HDF5") != 0) {
                         ERR("'no fill' option only available in HDF5");

--- a/testing/basic-tests.sh
+++ b/testing/basic-tests.sh
@@ -16,9 +16,9 @@ MDTEST 2 -a POSIX -W 2
 MDTEST 1 -C -T -r -F -I 1 -z 1 -b 1 -L -u
 MDTEST 1 -C -T -I 1 -z 1 -b 1 -u
 
-IOR 1 -a POSIX -w    -z                  -F -Y -e -i1 -m -t 100k -b 1000k
-IOR 1 -a POSIX -w    -z                  -F -k -e -i2 -m -t 100k -b 100k
-IOR 1 -a MMAP -r    -z                  -F -k -e -i1 -m -t 100k -b 100k
+IOR 1 -a POSIX -w    -z                 -F -Y -e -i1 -m -t 100k -b 1000k
+IOR 1 -a POSIX -w    -z                 -F -k -e -i2 -m -t 100k -b 100k
+IOR 1 -a MMAP  -r    -z                 -F -k -e -i1 -m -t 100k -b 100k
 
 IOR 2 -a POSIX -w    -z  -C             -F -k -e -i1 -m -t 100k -b 100k
 IOR 2 -a POSIX -w    -z  -C -Q 1        -F -k -e -i1 -m -t 100k -b 100k


### PR DESCRIPTION
I realize that NetCDF-4 is built on HDF5 (or PnetCDF, if enabled), and both HDF5 and PnetCDF are supported by IOR.  However, I routinely encounter issues related to the extra overhead that NetCDF add on top of HDF5, and for that reason I would like the ability to test NetCDF-4 along side HDF5, in the same framework.

I have noticed that testing seems a little light.  The only tests that appear to be run at the `testing/basic-tests.sh` script, which actually only tests the `POSIX` and `MMAP` APIs.  Are there plans to extend these tests?  I'm wondering how best to add tests for the new code in this PR (other than just testing if IOR can build with the `--with-nc4` configuration flag).