### PR TITLE
add mknod support

### DIFF
--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -107,6 +107,7 @@ ior_aiori_t posix_aiori = {
         .name = "POSIX",
         .name_legacy = NULL,
         .create = POSIX_Create,
+        .mknod = POSIX_Mknod,
         .open = POSIX_Open,
         .xfer = POSIX_Xfer,
         .close = POSIX_Close,
@@ -425,6 +426,24 @@ void *POSIX_Create(char *testFileName, IOR_param_t * param)
         }
 #endif
         return ((void *)fd);
+}
+
+/*
+ * Creat a file through mknod interface.
+ */
+void *POSIX_Mknod(char *testFileName)
+{
+	int *fd;
+
+	fd = (int *)malloc(sizeof(int));
+	if (fd == NULL)
+		ERR("Unable to malloc file descriptor");
+
+	*fd = mknod(testFileName, S_IFREG | S_IRUSR, 0);
+	if (*fd < 0)
+		ERR("mknod failed");
+
+	return ((void *)fd);
 }
 
 /*

--- a/src/aiori.h
+++ b/src/aiori.h
@@ -68,6 +68,7 @@ typedef struct ior_aiori {
         char *name;
         char *name_legacy;
         void *(*create)(char *, IOR_param_t *);
+        void *(*mknod)(char *);
         void *(*open)(char *, IOR_param_t *);
         IOR_offset_t (*xfer)(int, void *, IOR_size_t *,
                              IOR_offset_t, IOR_param_t *);
@@ -125,6 +126,7 @@ int aiori_posix_access (const char *path, int mode, IOR_param_t * param);
 int aiori_posix_stat (const char *path, struct stat *buf, IOR_param_t * param);
 
 void *POSIX_Create(char *testFileName, IOR_param_t * param);
+void *POSIX_Mknod(char *testFileName);
 void *POSIX_Open(char *testFileName, IOR_param_t * param);
 IOR_offset_t POSIX_GetFileSize(IOR_param_t * test, MPI_Comm testComm, char *testFileName);
 void POSIX_Delete(char *testFileName, IOR_param_t * param);


### PR DESCRIPTION
Add new option '-k' to support file creation test with mknod,
which is widely used in lustre.

Signed-off-by: Gu Zheng <gzheng@ddn.com>