### PR TITLE
Fixed shift.  Also cleaned up output messages

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -939,7 +939,7 @@ static void InitTests(IOR_test_t *tests, MPI_Comm com)
                 params->testComm = com;
                 params->nodes = params->numTasks / tasksPerNode;
                 params->tasksPerNode = tasksPerNode;
-                params->tasksBlockMapping = QueryNodeMapping(com);
+                params->tasksBlockMapping = QueryNodeMapping(com,false);
                 if (params->numTasks == 0) {
                   params->numTasks = size;
                 }
@@ -1223,7 +1223,7 @@ static void TestIoSys(IOR_test_t *test)
         }
         if (rank == 0 && params->reorderTasks == TRUE && verbose >= VERBOSE_1) {
                 fprintf(out_logfile,
-                        "Using reorderTasks '-C' (expecting block, not cyclic, task assignment)\n");
+                        "Using reorderTasks '-C' (useful to avoid read cache in client)\n");
                 fflush(out_logfile);
         }
         params->tasksPerNode = CountTasksPerNode(testComm);

--- a/src/ior.c
+++ b/src/ior.c
@@ -939,7 +939,7 @@ static void InitTests(IOR_test_t *tests, MPI_Comm com)
                 params->testComm = com;
                 params->nodes = params->numTasks / tasksPerNode;
                 params->tasksPerNode = tasksPerNode;
-                params->packedTasks = QueryNodeMapping(com);
+                params->tasksBlockMapping = QueryNodeMapping(com);
                 if (params->numTasks == 0) {
                   params->numTasks = size;
                 }
@@ -1361,11 +1361,9 @@ static void TestIoSys(IOR_test_t *test)
                         }
                         if (params->reorderTasks) {
                                 /* move two nodes away from writing node */
-                                int shift = 1;
-                                if (params->packedTasks) {
-                                    shift = params->tasksPerNode;
-                                } else {
-                                    shift = 1;
+                                int shift = 1; /* assume a by-node (round-robin) mapping of tasks to nodes */
+                                if (params->tasksBlockMapping) {
+                                    shift = params->tasksPerNode; /* switch to by-slot (contiguous block) mapping */
                                 }
                                 rankOffset = (2 * shift) % params->numTasks;
                         }
@@ -1403,11 +1401,9 @@ static void TestIoSys(IOR_test_t *test)
                         /* Constant process offset reading */
                         if (params->reorderTasks) {
                                 /* move one node away from writing node */ 
-                                int shift = 1;
-                                if (params->packedTasks) {
-                                    shift=params->tasksPerNode;
-                                } else {
-                                    shift=1;
+                                int shift = 1; /* assume a by-node (round-robin) mapping of tasks to nodes */
+                                if (params->tasksBlockMapping) {
+                                    shift=params->tasksPerNode; /* switch to a by-slot (contiguous block) mapping */
                                 }
                                 rankOffset = (params->taskPerNodeOffset * shift) % params->numTasks;
                         }

--- a/src/ior.h
+++ b/src/ior.h
@@ -100,6 +100,7 @@ typedef struct
     int numTasks;                    /* number of tasks for test */
     int nodes;                       /* number of nodes for test */
     int tasksPerNode;                /* number of tasks per node */
+    int packedTasks;                 /* are the tasks round-robin across nodes or are they packed tightly*/ 
     int repetitions;                 /* number of repetitions of test */
     int repCounter;                  /* rep counter */
     int multiFile;                   /* multiple files */

--- a/src/ior.h
+++ b/src/ior.h
@@ -100,7 +100,7 @@ typedef struct
     int numTasks;                    /* number of tasks for test */
     int nodes;                       /* number of nodes for test */
     int tasksPerNode;                /* number of tasks per node */
-    int packedTasks;                 /* are the tasks round-robin across nodes or are they packed tightly*/ 
+    int tasksBlockMapping;           /* are the tasks in contiguous blocks across nodes or round-robin */ 
     int repetitions;                 /* number of repetitions of test */
     int repCounter;                  /* rep counter */
     int multiFile;                   /* multiple files */

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -635,19 +635,13 @@ void mdtest_stat(const int random, const int dirs, const long dir_iter, const ch
         }
 
         if (-1 == backend->stat (item, &buf, &param)) {
-            if (dirs) {
-                if ( verbose >= 3 ) {
-                    fprintf( out_logfile, "V-3: Stat'ing directory \"%s\"\n", item );
-                    fflush( out_logfile );
-                }
-                FAIL("unable to stat directory");
-            } else {
-                if ( verbose >= 3 ) {
-                    fprintf( out_logfile, "V-3: Stat'ing file \"%s\"\n", item );
-                    fflush( out_logfile );
-                }
-                FAIL("unable to stat file");
+            char msg_buf[4096];
+            if ( verbose >=3 ) {
+                fprintf( out_logfile, "V-3: Stat'ing %s \"%s\"\n", dirs ? "directory" : "file", item );
+                fflush( out_logfile );
             }
+            snprintf(msg_buf, 4096, "unable to stat %s %s", dirs ? "directory" : "file", item);
+            FAIL("unable to stat directory");
         }
     }
 }

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1362,7 +1362,7 @@ void print_help (void) {
         "\t-p: pre-iteration delay (in seconds)\n"
         "\t-r: only remove files or directories left behind by previous runs\n"
         "\t-R: randomly stat files (optional argument for random seed)\n"
-        "\t-s: stride between the number of tasks for each test\n"
+        "\t-s: stride between the number of nodes for each test\n"
         "\t-S: shared file access (file only, no directories)\n"
         "\t-t: time unique working directory overhead\n"
         "\t-T: only stat files/dirs\n"
@@ -2191,7 +2191,8 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     pid = getpid();
     uid = getuid();
 
-    nodeCount = size / CountTasksPerNode(testComm);
+    tasksPerNode = CountTasksPerNode(testComm);
+    nodeCount = size / tasksPerNode;
 
     if (rank == 0) {
         fprintf(out_logfile, "-- started at %s --\n\n", PrintTimestamp());
@@ -2265,6 +2266,11 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
         fprintf( out_logfile, "depth                   : %d\n", depth );
         fprintf( out_logfile, "make_node               : %d\n", make_node );
         fflush( out_logfile );
+    }
+
+    /* set the shift to mimic IOR and shift by procs per node */
+    if (nstride > 0) {
+        nstride *= tasksPerNode;
     }
 
     /* setup total number of items and number of items per dir */

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -2067,11 +2067,13 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     VERBOSE(3,-1,"main (before display_freespace): testdirpath is '%s'", testdirpath );
 
     if (rank == 0) display_freespace(testdirpath);
-    int packedByNode = QueryNodeMapping(testComm);
+    int tasksBlockMapping = QueryNodeMapping(testComm);
 
     /* set the shift to mimic IOR and shift by procs per node */
     if (nstride > 0) {
-        if ( nodeCount > 1 && packedByNode ) {
+        if ( nodeCount > 1 && tasksBlockMapping ) {
+            /* the user set the stride presumably to get the consumer tasks on a different node than the producer tasks
+               however, if the mpirun scheduler placed the tasks by-slot (in a contiguous block) then we need to adjust the shift by ppn */
             nstride *= tasksPerNode;
         }
         VERBOSE(0,5,"Shifting ranks by %d for each phase.", nstride);

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -2268,11 +2268,6 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
         fflush( out_logfile );
     }
 
-    /* set the shift to mimic IOR and shift by procs per node */
-    if (nstride > 0) {
-        nstride *= tasksPerNode;
-    }
-
     /* setup total number of items and number of items per dir */
     if (depth <= 0) {
         num_dirs_in_tree = 1;
@@ -2381,6 +2376,17 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     }
 
     if (rank == 0) display_freespace(testdirpath);
+    int packedByNode = QueryNodeMapping(testComm);
+
+    /* set the shift to mimic IOR and shift by procs per node */
+    if (nstride > 0) {
+        if ( packedByNode ) {
+            nstride *= tasksPerNode;
+        }
+        if (rank == 0) {
+            fprintf(out_logfile, "Shifting ranks by %d for each phase.\n", nstride);
+        }
+    }
 
     if (verbose >= 3 && rank == 0) {
         fprintf(out_logfile,  "V-3: main (after display_freespace): testdirpath is \"%s\"\n", testdirpath );

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -455,7 +455,6 @@ void create_remove_items(int currDepth, const int dirs, const int create, const 
             if (collective) {
                 collective_helper(dirs, create, temp_path, 0, progress);
             } else {
-                printf("DEBUG %5d rank %d gonna create %s\n", __LINE__, rank, temp_path);
                 create_remove_items_helper(dirs, create, temp_path, 0, progress);
             }
         }
@@ -481,7 +480,6 @@ void create_remove_items(int currDepth, const int dirs, const int create, const 
                 if (collective) {
                     collective_helper(dirs, create, temp_path, currDir*items_per_dir, progress);
                 } else {
-                    printf("DEBUG %5d rank %d gonna create %s\n", __LINE__, rank, temp_path);
                     create_remove_items_helper(dirs, create, temp_path, currDir*items_per_dir, progress);
                 }
             }
@@ -1196,66 +1194,6 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
     VERBOSE(1,-1,"  File stat         : %14.3f sec, %14.3f ops/sec", t[2] - t[1], summary_table[iteration].rate[5]);
     VERBOSE(1,-1,"  File read         : %14.3f sec, %14.3f ops/sec", t[3] - t[2], summary_table[iteration].rate[6]);
     VERBOSE(1,-1,"  File removal      : %14.3f sec, %14.3f ops/sec", t[4] - t[3], summary_table[iteration].rate[7]);
-}
-
-void print_help (void) {
-    int j;
-
-    char APIs[1024];
-    char APIs_legacy[1024];
-    aiori_supported_apis(APIs, APIs_legacy, MDTEST);
-    char apiStr[1024];
-    sprintf(apiStr, "API for I/O [%s]", APIs);
-
-    fprintf(out_logfile,
-        "Usage: mdtest [-b branching_factor] [-B] [-c] [-C] [-d testdir] [-D] [-e number_of_bytes_to_read]\n"
-        "              [-E] [-f first] [-F] [-h] [-i iterations] [-I items_per_dir] [-k] [-l last] [-L]\n"
-        "              [-n number_of_items] [-N stride_length] [-p seconds] [-r]\n"
-        "              [-R[seed]] [-s stride] [-S] [-t] [-T] [-u] [-v] [-a API]\n"
-        "              [-V verbosity_value] [-w number_of_bytes_to_write] [-W seconds] [-y] [-z depth] -Z\n"
-        "\t-a: %s\n"
-        "\t-b: branching factor of hierarchical directory structure\n"
-        "\t-B: no barriers between phases\n"
-        "\t-c: collective creates: task 0 does all creates\n"
-        "\t-C: only create files/dirs\n"
-        "\t-d: the directory in which the tests will run\n"
-        "\t-D: perform test on directories only (no files)\n"
-        "\t-e: bytes to read from each file\n"
-        "\t-E: only read files/dir\n"
-        "\t-f: first number of tasks on which the test will run\n"
-        "\t-F: perform test on files only (no directories)\n"
-        "\t-h: prints this help message\n"
-        "\t-i: number of iterations the test will run\n"
-        "\t-I: number of items per directory in tree\n"
-        "\t-k: use mknod\n"
-        "\t-l: last number of tasks on which the test will run\n"
-        "\t-L: files only at leaf level of tree\n"
-        "\t-n: every process will creat/stat/read/remove # directories and files\n"
-        "\t-N: stride # between neighbor tasks for file/dir operation (local=0)\n"
-        "\t-p: pre-iteration delay (in seconds)\n"
-        "\t-r: only remove files or directories left behind by previous runs\n"
-        "\t-R: randomly stat files (optional argument for random seed)\n"
-        "\t-s: stride between the number of nodes for each test\n"
-        "\t-S: shared file access (file only, no directories)\n"
-        "\t-t: time unique working directory overhead\n"
-        "\t-T: only stat files/dirs\n"
-        "\t-u: unique working directory for each task\n"
-        "\t-v: verbosity (each instance of option increments by one)\n"
-        "\t-V: verbosity value\n"
-        "\t-w: bytes to write to each file after it is created\n"
-        "\t-W: number in seconds; stonewall timer, write as many seconds and ensure all processes did the same number of operations (currently only stops during create phase)\n"
-        "\t-x: StoneWallingStatusFile; contains the number of iterations of the creation phase, can be used to split phases across runs\n"
-        "\t-y: sync file after writing\n"
-        "\t-z: depth of hierarchical directory structure\n"
-        "\t-Z: print time instead of rate\n",
-        apiStr
-        );
-
-    MPI_Initialized(&j);
-    if (j) {
-        MPI_Finalize();
-    }
-    exit(0);
 }
 
 void summarize_results(int iterations) {

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1862,7 +1862,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
       {'l', NULL,        "last number of tasks on which the test will run", OPTION_OPTIONAL_ARGUMENT, 'd', & last},
       {'L', NULL,        "files only at leaf level of tree", OPTION_FLAG, 'd', & leaf_only},
       {'n', NULL,        "every process will creat/stat/read/remove # directories and files", OPTION_OPTIONAL_ARGUMENT, 'l', & items},
-      {'N', NULL,        "stride # between neighbor tasks for file/dir operation (local=0)", OPTION_OPTIONAL_ARGUMENT, 'd', & nstride},
+      {'N', NULL,        "stride # between tasks for file/dir operation (local=0; set to 1 to avoid client cache)", OPTION_OPTIONAL_ARGUMENT, 'd', & nstride},
       {'p', NULL,        "pre-iteration delay (in seconds)", OPTION_OPTIONAL_ARGUMENT, 'd', & pre_delay},
       {'R', NULL,        "random access to files (only for stat)", OPTION_FLAG, 'd', & randomize},
       {0, "random-seed", "random seed for -R", OPTION_OPTIONAL_ARGUMENT, 'd', & random_seed},
@@ -2065,7 +2065,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     VERBOSE(3,-1,"main (before display_freespace): testdirpath is '%s'", testdirpath );
 
     if (rank == 0) display_freespace(testdirpath);
-    int tasksBlockMapping = QueryNodeMapping(testComm);
+    int tasksBlockMapping = QueryNodeMapping(testComm, true);
 
     /* set the shift to mimic IOR and shift by procs per node */
     if (nstride > 0) {

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -284,7 +284,7 @@ static void create_remove_dirs (const char *path, bool create, uint64_t itemNum)
 
     //create dirs
     sprintf(curr_item, "%s/dir.%s%" PRIu64, path, create ? mk_name : rm_name, itemNum);
-    VERBOSE(3,5,"create_remove_items_helper (dirs %s): curr_item is \"%s\"", operation, curr_item);
+    VERBOSE(3,5,"create_remove_items_helper (dirs %s): curr_item is '%s'", operation, curr_item);
 
     if (create) {
         if (backend->mkdir(curr_item, DIRMODE, &param) == -1) {
@@ -306,7 +306,7 @@ static void remove_file (const char *path, uint64_t itemNum) {
 
     //remove files
     sprintf(curr_item, "%s/file.%s"LLU"", path, rm_name, itemNum);
-    VERBOSE(3,5,"create_remove_items_helper (non-dirs remove): curr_item is \"%s\"", curr_item);
+    VERBOSE(3,5,"create_remove_items_helper (non-dirs remove): curr_item is '%s'", curr_item);
     if (!(shared_file && rank != 0)) {
         backend->delete (curr_item, &param);
     }
@@ -322,7 +322,7 @@ static void create_file (const char *path, uint64_t itemNum) {
 
     //create files
     sprintf(curr_item, "%s/file.%s"LLU"", path, mk_name, itemNum);
-    VERBOSE(3,5,"create_remove_items_helper (non-dirs create): curr_item is \"%s\"", curr_item);
+    VERBOSE(3,5,"create_remove_items_helper (non-dirs create): curr_item is '%s'", curr_item);
 
     if (collective_creates) {
         param.openFlags = IOR_WRONLY;
@@ -453,7 +453,7 @@ void create_remove_items(int currDepth, const int dirs, const int create, const 
     memset(dir, 0, MAX_PATHLEN);
     strcpy(temp_path, path);
 
-    VERBOSE(3,5,"create_remove_items (start): temp_path is \"%s\"", temp_path );
+    VERBOSE(3,5,"create_remove_items (start): temp_path is '%s'", temp_path );
 
     if (currDepth == 0) {
         /* create items at this depth */
@@ -479,7 +479,7 @@ void create_remove_items(int currDepth, const int dirs, const int create, const 
             strcat(temp_path, "/");
             strcat(temp_path, dir);
 
-            VERBOSE(3,5,"create_remove_items (for loop): temp_path is \"%s\"", temp_path );
+            VERBOSE(3,5,"create_remove_items (for loop): temp_path is '%s'", temp_path );
 
             /* create the items in this branch */
             if (!leaf_only || (leaf_only && currDepth == depth)) {
@@ -742,7 +742,7 @@ void collective_create_remove(const int create, const int dirs, const int ntasks
         }
 
         /* Now that everything is set up as it should be, do the create or remove */
-        VERBOSE(3,5,"collective_create_remove (create_remove_items): temp is \"%s\"", temp);
+        VERBOSE(3,5,"collective_create_remove (create_remove_items): temp is '%s'", temp);
 
         create_remove_items(0, dirs, create, 1, temp, 0, progress);
     }
@@ -799,7 +799,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
             sprintf( temp_path, "%s/%s", testdir, path );
         }
 
-        VERBOSE(3,-1,"directory_test: create path is \"%s\"", temp_path );
+        VERBOSE(3,-1,"directory_test: create path is '%s'", temp_path );
 
         /* "touch" the files */
         if (collective_creates) {
@@ -831,7 +831,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
             sprintf( temp_path, "%s/%s", testdir, path );
         }
 
-        VERBOSE(3,5,"stat path is \"%s\"", temp_path );
+        VERBOSE(3,5,"stat path is '%s'", temp_path );
 
         /* stat directories */
         if (random_seed > 0) {
@@ -860,7 +860,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
             sprintf( temp_path, "%s/%s", testdir, path );
         }
 
-        VERBOSE(3,5,"directory_test: read path is \"%s\"", temp_path );
+        VERBOSE(3,5,"directory_test: read path is '%s'", temp_path );
 
         /* read directories */
         if (random_seed > 0) {
@@ -888,7 +888,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
             sprintf( temp_path, "%s/%s", testdir, path );
         }
 
-        VERBOSE(3,5,"directory_test: remove directories path is \"%s\"", temp_path );
+        VERBOSE(3,5,"directory_test: remove directories path is '%s'", temp_path );
 
         /* remove directories */
         if (collective_creates) {
@@ -913,7 +913,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
             sprintf( temp_path, "%s/%s", testdir, path );
         }
 
-        VERBOSE(3,5,"directory_test: remove unique directories path is \"%s\"\n", temp_path );
+        VERBOSE(3,5,"directory_test: remove unique directories path is '%s'\n", temp_path );
     }
 
     if (unique_dir_per_task && !time_unique_dir_overhead) {
@@ -1010,7 +1010,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
 
 
 
-        VERBOSE(3,-1,"file_test: create path is \"%s\"", temp_path );
+        VERBOSE(3,-1,"file_test: create path is '%s'", temp_path );
 
         /* "touch" the files */
         if (collective_creates) {
@@ -1077,7 +1077,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
             sprintf( temp_path, "%s/%s", testdir, path );
         }
 
-        VERBOSE(3,5,"file_test: stat path is \"%s\"", temp_path );
+        VERBOSE(3,5,"file_test: stat path is '%s'", temp_path );
 
         /* stat files */
         mdtest_stat((random_seed > 0 ? 1 : 0), 0, dir_iter, temp_path, progress);
@@ -1102,7 +1102,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
             sprintf( temp_path, "%s/%s", testdir, path );
         }
 
-        VERBOSE(3,5,"file_test: read path is \"%s\"", temp_path );
+        VERBOSE(3,5,"file_test: read path is '%s'", temp_path );
 
         /* read files */
         if (random_seed > 0) {
@@ -1132,7 +1132,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
             sprintf( temp_path, "%s/%s", testdir, path );
         }
 
-        VERBOSE(3,5,"file_test: rm directories path is \"%s\"", temp_path );
+        VERBOSE(3,5,"file_test: rm directories path is '%s'", temp_path );
 
         if (collective_creates) {
             if (rank == 0) {
@@ -1156,7 +1156,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
             strcpy( temp_path, path );
         }
 
-        VERBOSE(3,5,"file_test: rm unique directories path is \"%s\"", temp_path );
+        VERBOSE(3,5,"file_test: rm unique directories path is '%s'", temp_path );
     }
 
     if (unique_dir_per_task && !time_unique_dir_overhead) {
@@ -1508,9 +1508,9 @@ void display_freespace(char *testdirpath)
         strcpy(dirpath, ".");
     }
 
-    VERBOSE(3,5,"Before show_file_system_size, dirpath is \"%s\"", dirpath );
+    VERBOSE(3,5,"Before show_file_system_size, dirpath is '%s'", dirpath );
     show_file_system_size(dirpath);
-    VERBOSE(3,5, "After show_file_system_size, dirpath is \"%s\"\n", dirpath );
+    VERBOSE(3,5, "After show_file_system_size, dirpath is '%s'\n", dirpath );
 
     return;
 }
@@ -1528,16 +1528,16 @@ void create_remove_directory_tree(int create,
         sprintf(dir, "%s/%s.%d/", path, base_tree_name, dirNum);
 
         if (create) {
-            VERBOSE(2,5,"Making directory \"%s\"", dir);
+            VERBOSE(2,5,"Making directory '%s'", dir);
             if (-1 == backend->mkdir (dir, DIRMODE, &param)) {
-                fprintf(out_logfile, "error could not create directory \"%s\"\n", dir);
+                fprintf(out_logfile, "error could not create directory '%s'\n", dir);
             }
         }
 
         create_remove_directory_tree(create, ++currDepth, dir, ++dirNum, progress);
 
         if (!create) {
-            VERBOSE(2,5,"Remove directory \"%s\"", dir);
+            VERBOSE(2,5,"Remove directory '%s'", dir);
             if (-1 == backend->rmdir(dir, &param)) {
                 FAIL("Unable to remove directory");
             }
@@ -1553,7 +1553,7 @@ void create_remove_directory_tree(int create,
             strcat(temp_path, dir);
 
             if (create) {
-                VERBOSE(2,5,"Making directory \"%s\"", temp_path);
+                VERBOSE(2,5,"Making directory '%s'", temp_path);
                 if (-1 == backend->mkdir(temp_path, DIRMODE, &param)) {
                     FAIL("Unable to create directory");
                 }
@@ -1564,7 +1564,7 @@ void create_remove_directory_tree(int create,
             currDepth--;
 
             if (!create) {
-                VERBOSE(2,5,"Remove directory \"%s\"", temp_path);
+                VERBOSE(2,5,"Remove directory '%s'", temp_path);
                 if (-1 == backend->rmdir(temp_path, &param)) {
                     FAIL("Unable to remove directory");
                 }
@@ -1593,7 +1593,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
   for (int dir_iter = 0; dir_iter < directory_loops; dir_iter ++){
     prep_testdir(j, dir_iter);
 
-    VERBOSE(2,5,"main (for j loop): making testdir, \"%s\"", testdir );
+    VERBOSE(2,5,"main (for j loop): making testdir, '%s'", testdir );
     if ((rank < path_count) && backend->access(testdir, F_OK, &param) != 0) {
         if (backend->mkdir(testdir, DIRMODE, &param) != 0) {
             FAIL("Unable to create test directory");
@@ -1618,7 +1618,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
                 for (k=0; k<size; k++) {
                     sprintf(base_tree_name, "mdtest_tree.%d", k);
 
-                    VERBOSE(3,5,"main (create hierarchical directory loop-collective): Calling create_remove_directory_tree with \"%s\"", testdir );
+                    VERBOSE(3,5,"main (create hierarchical directory loop-collective): Calling create_remove_directory_tree with '%s'", testdir );
                     /*
                      * Let's pass in the path to the directory we most recently made so that we can use
                      * full paths in the other calls.
@@ -1630,7 +1630,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
                     }
                 }
             } else if (!collective_creates) {
-                VERBOSE(3,5,"main (create hierarchical directory loop-!collective_creates): Calling create_remove_directory_tree with \"%s\"", testdir );
+                VERBOSE(3,5,"main (create hierarchical directory loop-!collective_creates): Calling create_remove_directory_tree with '%s'", testdir );
                 /*
                  * Let's pass in the path to the directory we most recently made so that we can use
                  * full paths in the other calls.
@@ -1639,7 +1639,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
             }
         } else {
             if (rank == 0) {
-                VERBOSE(3,5,"main (create hierarchical directory loop-!unque_dir_per_task): Calling create_remove_directory_tree with \"%s\"", testdir );
+                VERBOSE(3,5,"main (create hierarchical directory loop-!unque_dir_per_task): Calling create_remove_directory_tree with '%s'", testdir );
 
                 /*
                  * Let's pass in the path to the directory we most recently made so that we can use
@@ -1666,7 +1666,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
   unique_rm_uni_dir[0] = 0;
 
   if (!unique_dir_per_task) {
-    VERBOSE(3,-1,"V-3: main: Using unique_mk_dir, \"%s\"", unique_mk_dir );
+    VERBOSE(3,-1,"V-3: main: Using unique_mk_dir, '%s'", unique_mk_dir );
   }
 
   if (rank < i) {
@@ -1687,7 +1687,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
           VERBOSE(5,5,"mk_dir %s chdir %s stat_dir %s read_dir %s rm_dir %s\n", unique_mk_dir,unique_chdir_dir,unique_stat_dir,unique_read_dir,unique_rm_dir);
       }
 
-      VERBOSE(3,-1,"V-3: main: Copied unique_mk_dir, \"%s\", to topdir", unique_mk_dir );
+      VERBOSE(3,-1,"V-3: main: Copied unique_mk_dir, '%s', to topdir", unique_mk_dir );
 
       if (dirs_only && !shared_file) {
           if (pre_delay) {
@@ -1706,7 +1706,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
 
   /* remove directory structure */
   if (!unique_dir_per_task) {
-      VERBOSE(3,-1,"main: Using testdir, \"%s\"", testdir );
+      VERBOSE(3,-1,"main: Using testdir, '%s'", testdir );
   }
 
   MPI_Barrier(testComm);
@@ -1724,7 +1724,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
                 for (k=0; k<size; k++) {
                     sprintf(base_tree_name, "mdtest_tree.%d", k);
 
-                    VERBOSE(3,-1,"main (remove hierarchical directory loop-collective): Calling create_remove_directory_tree with \"%s\"", testdir );
+                    VERBOSE(3,-1,"main (remove hierarchical directory loop-collective): Calling create_remove_directory_tree with '%s'", testdir );
 
                     /*
                      * Let's pass in the path to the directory we most recently made so that we can use
@@ -1737,7 +1737,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
                     }
                 }
             } else if (!collective_creates) {
-                VERBOSE(3,-1,"main (remove hierarchical directory loop-!collective): Calling create_remove_directory_tree with \"%s\"", testdir );
+                VERBOSE(3,-1,"main (remove hierarchical directory loop-!collective): Calling create_remove_directory_tree with '%s'", testdir );
 
                 /*
                  * Let's pass in the path to the directory we most recently made so that we can use
@@ -1747,7 +1747,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
             }
         } else {
             if (rank == 0) {
-                VERBOSE(3,-1,"V-3: main (remove hierarchical directory loop-!unique_dir_per_task): Calling create_remove_directory_tree with \"%s\"", testdir );
+                VERBOSE(3,-1,"V-3: main (remove hierarchical directory loop-!unique_dir_per_task): Calling create_remove_directory_tree with '%s'", testdir );
 
                 /*
                  * Let's pass in the path to the directory we most recently made so that we can use
@@ -1765,7 +1765,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
       summary_table->items[9] = num_dirs_in_tree;
       summary_table->stonewall_last_item[8] = num_dirs_in_tree;
       VERBOSE(1,-1,"main   Tree removal      : %14.3f sec, %14.3f ops/sec", (endCreate - startCreate), summary_table->rate[9]);
-      VERBOSE(2,-1,"main (at end of for j loop): Removing testdir of \"%s\"\n", testdir );
+      VERBOSE(2,-1,"main (at end of for j loop): Removing testdir of '%s'\n", testdir );
 
       for (int dir_iter = 0; dir_iter < directory_loops; dir_iter ++){
         prep_testdir(j, dir_iter);
@@ -1900,7 +1900,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     char cmd_buffer[4096];
     strncpy(cmd_buffer, argv[0], 4096);
     for (i = 1; i < argc; i++) {
-        snprintf(&cmd_buffer[strlen(cmd_buffer)], 4096-strlen(cmd_buffer), " \"%s\"", argv[i]);
+        snprintf(&cmd_buffer[strlen(cmd_buffer)], 4096-strlen(cmd_buffer), " '%s'", argv[i]);
     }
 
     VERBOSE(0,-1,"-- started at %s --\n", PrintTimestamp());
@@ -2064,7 +2064,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     }
 
     /* display disk usage */
-    VERBOSE(3,-1,"main (before display_freespace): testdirpath is \"%s\"", testdirpath );
+    VERBOSE(3,-1,"main (before display_freespace): testdirpath is '%s'", testdirpath );
 
     if (rank == 0) display_freespace(testdirpath);
     int packedByNode = QueryNodeMapping(testComm);
@@ -2077,7 +2077,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
         VERBOSE(0,5,"Shifting ranks by %d for each phase.", nstride);
     }
 
-    VERBOSE(3,-1,"main (after display_freespace): testdirpath is \"%s\"", testdirpath );
+    VERBOSE(3,-1,"main (after display_freespace): testdirpath is '%s'", testdirpath );
 
     if (rank == 0) {
         if (random_seed > 0) {

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -551,12 +551,12 @@ void mdtest_stat(const int random, const int dirs, const long dir_iter, const ch
 
         /* create name of file/dir to stat */
         if (dirs) {
-            if ((i%ITEM_COUNT == 0) && (i != 0)) {
+            if ( (i % ITEM_COUNT == 0) && (i != 0)) {
                 VERBOSE(3,5,"stat dir: "LLU"", i);
             }
             sprintf(item, "dir.%s"LLU"", stat_name, item_num);
         } else {
-            if ((i%ITEM_COUNT == 0) && (i != 0)) {
+            if ( (i % ITEM_COUNT == 0) && (i != 0)) {
                 VERBOSE(3,5,"stat file: "LLU"", i);
             }
             sprintf(item, "file.%s"LLU"", stat_name, item_num);

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -494,6 +494,7 @@ void create_remove_items(int currDepth, const int dirs, const int create, const 
             if (collective) {
                 collective_helper(dirs, create, temp_path, 0, progress);
             } else {
+                printf("DEBUG %5d rank %d gonna create %s\n", __LINE__, rank, temp_path);
                 create_remove_items_helper(dirs, create, temp_path, 0, progress);
             }
         }
@@ -522,6 +523,7 @@ void create_remove_items(int currDepth, const int dirs, const int create, const 
                 if (collective) {
                     collective_helper(dirs, create, temp_path, currDir*items_per_dir, progress);
                 } else {
+                    printf("DEBUG %5d rank %d gonna create %s\n", __LINE__, rank, temp_path);
                     create_remove_items_helper(dirs, create, temp_path, currDir*items_per_dir, progress);
                 }
             }
@@ -641,7 +643,7 @@ void mdtest_stat(const int random, const int dirs, const long dir_iter, const ch
                 fflush( out_logfile );
             }
             snprintf(msg_buf, 4096, "unable to stat %s %s", dirs ? "directory" : "file", item);
-            FAIL("unable to stat directory");
+            FAIL(msg_buf);
         }
     }
 }
@@ -792,6 +794,7 @@ void collective_create_remove(const int create, const int dirs, const int ntasks
             sprintf(rm_name, "mdtest.%d.", (i+(3*nstride))%ntasks);
         }
         if (unique_dir_per_task) {
+            printf("DEBUG %5d Rank %d i %d nstride %d ntasks %d", __LINE__, rank, i, nstride, ntasks);
             sprintf(unique_mk_dir, "%s/mdtest_tree.%d.0", testdir,
                     (i+(0*nstride))%ntasks);
             sprintf(unique_chdir_dir, "%s/mdtest_tree.%d.0", testdir,
@@ -1085,6 +1088,8 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
     char temp_path[MAX_PATHLEN];
     MPI_Comm_size(testComm, &size);
 
+    printf("DEBUG %5d Rank %d file_test on %s\n", __LINE__, rank, path);
+
     if (( rank == 0 ) && ( verbose >= 1 )) {
         fprintf( out_logfile, "V-1: Entering file_test...\n" );
         fflush( out_logfile );
@@ -1099,13 +1104,17 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
         prep_testdir(iteration, dir_iter);
 
         if (unique_dir_per_task) {
+            printf("DEBUG %5d Rank %d operating on %s\n", __LINE__, rank, temp_path);
             unique_dir_access(MK_UNI_DIR, temp_path);
+            printf("DEBUG %5d Rank %d operating on %s\n", __LINE__, rank, temp_path);
             if (!time_unique_dir_overhead) {
                 offset_timers(t, 0);
             }
         } else {
             sprintf( temp_path, "%s/%s", testdir, path );
         }
+
+
 
         if (verbose >= 3 && rank == 0) {
             fprintf(out_logfile,  "V-3: file_test: create path is \"%s\"\n", temp_path );
@@ -1250,6 +1259,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
                 collective_create_remove(0, 0, ntasks, temp_path, progress);
             }
         } else {
+            printf("DEBUG %5d rank %d gonna create %s\n", __LINE__, rank, temp_path);
             create_remove_items(0, 0, 0, 0, temp_path, 0, progress);
         }
       }
@@ -1942,12 +1952,15 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
           sprintf(rm_name, "mdtest.%d.", (rank+(3*nstride))%i);
       }
       if (unique_dir_per_task) {
+          printf("DEBUG %5d Rank %d i %d nstride %d\n", __LINE__, rank, i, nstride);
           sprintf(unique_mk_dir, "mdtest_tree.%d.0",  (rank+(0*nstride))%i);
           sprintf(unique_chdir_dir, "mdtest_tree.%d.0", (rank+(1*nstride))%i);
           sprintf(unique_stat_dir, "mdtest_tree.%d.0", (rank+(2*nstride))%i);
           sprintf(unique_read_dir, "mdtest_tree.%d.0", (rank+(3*nstride))%i);
           sprintf(unique_rm_dir, "mdtest_tree.%d.0", (rank+(4*nstride))%i);
           unique_rm_uni_dir[0] = 0;
+          printf("DEBUG %5d Rank %d mk_dir %s chdir %s stat_dir %s read_dir %s rm_dir %s\n", __LINE__, 
+                  rank, unique_mk_dir,unique_chdir_dir,unique_stat_dir,unique_read_dir,unique_rm_dir);
       }
 
       if (verbose >= 3 && rank == 0) {
@@ -1965,6 +1978,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
           if (pre_delay) {
               DelaySecs(pre_delay);
           }
+          printf("DEBUG %5d Rank %d gonna file_test on %s\n", __LINE__, rank, unique_mk_dir);
           file_test(j, i, unique_mk_dir, progress);
       }
   }

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -471,7 +471,7 @@ option_help * createGlobalOptions(IOR_param_t * params){
     {'A', NULL,        "refNum -- user supplied reference number to include in the summary", OPTION_OPTIONAL_ARGUMENT, 'd', & params->referenceNumber},
     {'b', NULL,        "blockSize -- contiguous bytes to write per task  (e.g.: 8, 4k, 2m, 1g)", OPTION_OPTIONAL_ARGUMENT, 'l', & params->blockSize},
     {'c', NULL,        "collective -- collective I/O", OPTION_FLAG, 'd', & params->collective},
-    {'C', NULL,        "reorderTasks -- changes task ordering to n+1 ordering for readback", OPTION_FLAG, 'd', & params->reorderTasks},
+    {'C', NULL,        "reorderTasks -- changes task ordering for readback (useful to avoid client cache)", OPTION_FLAG, 'd', & params->reorderTasks},
     {'d', NULL,        "interTestDelay -- delay between reps in seconds", OPTION_OPTIONAL_ARGUMENT, 'd', & params->interTestDelay},
     {'D', NULL,        "deadlineForStonewalling -- seconds before stopping write or read phase", OPTION_OPTIONAL_ARGUMENT, 'd', & params->deadlineForStonewalling},
     {.help="  -O stoneWallingWearOut=1           -- once the stonewalling timout is over, all process finish to access the amount of data", .arg = OPTION_OPTIONAL_ARGUMENT},

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -20,6 +20,7 @@
 #  define _GNU_SOURCE            /* Needed for O_DIRECT in fcntl */
 #endif                           /* __linux__ */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -75,6 +76,17 @@ void* safeMalloc(uint64_t size){
   return d;
 }
 
+void FailMessage(int rank, const char *location, char *format, ...) {
+    char msg[4096];                                                  
+    va_list args;
+    va_start(args, format);
+    vsnprintf(msg, 4096, format, args);
+    va_end(args);
+    fprintf(out_logfile, "%s: Process %d: FAILED in %s, %s: %s\n", 
+                PrintTimestamp(), rank, location, msg, strerror(errno));                               
+    fflush(out_logfile);                                        
+    MPI_Abort(testComm, 1);                                    
+}
 
 size_t NodeMemoryStringToBytes(char *size_str)
 {

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -229,7 +229,7 @@ void DumpBuffer(void *buffer,
    and the value is whether that rank is on the same host as root.
    Also returns 1 if rank 1 is on same host and 0 otherwise
 */
-int QueryNodeMapping(MPI_Comm comm) {
+int QueryNodeMapping(MPI_Comm comm, int print_nodemap) {
     char localhost[MAX_PATHLEN], roothost[MAX_PATHLEN];
     int num_ranks;
     MPI_Comm_size(comm, &num_ranks);
@@ -250,7 +250,7 @@ int QueryNodeMapping(MPI_Comm comm) {
     /* then every rank figures out whether it is same host as root and then gathers that */
     int same_as_root = strcmp(roothost,localhost) == 0;
     MPI_Gather( &same_as_root, 1, MPI_INT, node_map, 1, MPI_INT, 0, comm);
-    if (rank==0) {
+    if ( print_nodemap && rank==0) {
         fprintf( out_logfile, "Nodemap: " );
         for ( int i = 0; i < num_ranks; i++ ) {
             fprintf( out_logfile, "%d", node_map[i] );

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -246,6 +246,7 @@ int QueryNodeMapping(MPI_Comm comm) {
         fprintf( out_logfile, "\n" );
     }
     int ret = node_map[1] == 1;
+    MPI_Bcast(&ret, 1, MPI_INT, 0, comm);
     free(node_map);
     return ret;
 }

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -56,7 +56,7 @@ void SetHints (MPI_Info *, char *);
 void ShowHints (MPI_Info *);
 char *HumanReadable(IOR_offset_t value, int base);
 int CountTasksPerNode(MPI_Comm comm);
-int QueryNodeMapping(MPI_Comm comm);
+int QueryNodeMapping(MPI_Comm comm, int print_nodemap);
 void DelaySecs(int delay);
 void updateParsedOptions(IOR_param_t * options, options_all_t * global_options);
 size_t NodeMemoryStringToBytes(char *size_str);

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -36,22 +36,13 @@ extern enum OutputFormat_t outputFormat;  /* format of the output */
 
 
 #ifdef __linux__
-#define FAIL(msg) do {                                                   \
-        fprintf(out_logfile, "%s: Process %d: FAILED in %s, %s: %s\n",   \
-                PrintTimestamp(), rank, __func__,                       \
-                msg, strerror(errno));                                   \
-        fflush(out_logfile);                                             \
-        MPI_Abort(testComm, 1);                                          \
-    } while(0)
+#define ERROR_LOCATION __func__
 #else
-#define FAIL(msg) do {                                                   \
-        fprintf(out_logfile, "%s: Process %d: FAILED at %d, %s: %s\n",   \
-                PrintTimestamp(), rank, __LINE__,                       \
-                msg, strerror(errno));                                   \
-        fflush(out_logfile);                                             \
-        MPI_Abort(testComm, 1);                                          \
-    } while(0)
+#define ERROR_LOCATION __LINE__
 #endif
+
+#define FAIL(...) FailMessage(rank, ERROR_LOCATION, __VA_ARGS__)
+void FailMessage(int rank, const char *location, char *format, ...);
 
 void* safeMalloc(uint64_t size);
 void set_o_direct_flag(int *fd);

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -65,6 +65,7 @@ void SetHints (MPI_Info *, char *);
 void ShowHints (MPI_Info *);
 char *HumanReadable(IOR_offset_t value, int base);
 int CountTasksPerNode(MPI_Comm comm);
+int QueryNodeMapping(MPI_Comm comm);
 void DelaySecs(int delay);
 void updateParsedOptions(IOR_param_t * options, options_all_t * global_options);
 size_t NodeMemoryStringToBytes(char *size_str);


### PR DESCRIPTION
If you look at the differences, they appear like a lot but the overwhelming majority are merely cleaning up output messages in mdtest.  It used to have at least 3 lines for every output message because it wrapped each one up in a if branch testing for verbosity.  I added a helper function so now it is just one line of code for each output message.

There there is also a new function added in utilities which prints the node map (a 0 or 1 for every rank where 0 means on a different node from rank 0 and 1 means same node) which also returns whether the node/task mapping is round-robin or contiguous.

Then a small change in mdtest to shift by ppn if contiguous or 1 otherwise.  It used to only shift by 1 so it used to only work when the mapping was round robin.  Now it works for both.

Then a small change in IOR to do the same.  It used to only shift by ppn so it used to only work when the mapping was contiguous.  Now it works for both.

I tested the code at small scale and Ken Carlilie (thanks Ken!) tested at large scale.