### PR TITLE
fixes #164 - HDF5 backend won't compile with HDF5 >= 1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     # Install MPI
     - sudo apt-get install -y openmpi-bin libopenmpi-dev
     # Install HDF5
-    - sudo apt-get install -y hdf5-tools libhdf5-mpi-dev
+    - sudo apt-get install -y hdf5-tools libhdf5-openmpi-dev
     # Install Lustre
     # TODO: As far as a i can see it needs to be compiled form source with kernel
     # module as there is no package.
@@ -22,10 +22,13 @@ install:
     # Install HDFS
     # TODO: Not sure with which c libray hdfs should be used and if it is in
     # the ubuntu repos
-    # Probably hadoop needs to be installed an provides nativ api.
+    # Probably hadoop needs to be installed an provides native API.
     # Install Amazon S3
     # TODO: The needed library needs to be installed. Follow the instructions in
     # aiori-S3.c to achive this.
     # GPFS
     # NOTE: Think GPFS need a license and is therefore not testable with travis.
-script: ./travis-build.sh && CONFIGURE_OPTS="--with-hdf5" ./travis-test.sh
+script:
+    - ./travis-build.sh
+    - export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/hdf5/openmpi:${LD_LIBRARY_PATH}
+    - CONFIGURE_OPTS="--with-hdf5" CFLAGS="-I/usr/include/hdf5/openmpi -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi" ./travis-test.sh

--- a/configure.ac
+++ b/configure.ac
@@ -100,8 +100,6 @@ AC_ARG_WITH([hdf5],
 AM_CONDITIONAL([USE_HDF5_AIORI], [test x$with_hdf5 = xyes])
 AM_COND_IF([USE_HDF5_AIORI],[
         AC_DEFINE([USE_HDF5_AIORI], [], [Build HDF5 backend AIORI])
-	AC_SEARCH_LIBS([H5Pset_all_coll_metadata_ops], [hdf5])
-	AC_CHECK_FUNCS([H5Pset_all_coll_metadata_ops])
 ])
 
 

--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -228,17 +228,6 @@ static void *HDF5_Open(char *testFileName, IOR_param_t * param)
                                     param->setAlignment),
                    "cannot set alignment");
 
-#ifdef HAVE_H5PSET_ALL_COLL_METADATA_OPS
-        if (param->collective_md) {
-                /* more scalable metadata */
-
-                HDF5_CHECK(H5Pset_all_coll_metadata_ops(accessPropList, 1),
-                        "cannot set collective md read");
-                HDF5_CHECK(H5Pset_coll_metadata_write(accessPropList, 1),
-                        "cannot set collective md write");
-        }
-#endif
-
         /* open file */
         if (param->open == WRITE) {     /* WRITE */
                 *fd = H5Fcreate(testFileName, fd_mode,


### PR DESCRIPTION
Fixes #164.  Was easier than I thought.