### PR TITLE
Fix: Heap Buffer Overflow

### DIFF
--- a/src/utilities.c
+++ b/src/utilities.c
@@ -257,7 +257,9 @@ int QueryNodeMapping(MPI_Comm comm, int print_nodemap) {
         }
         fprintf( out_logfile, "\n" );
     }
-    int ret = node_map[1] == 1;
+    int ret = 1;
+    if(num_ranks>1)
+        ret = node_map[1] == 1;
     MPI_Bcast(&ret, 1, MPI_INT, 0, comm);
     free(node_map);
     return ret;


### PR DESCRIPTION
Fix a memory violation when run in serial.

Found via gcc's `-fsanitize=address` sanitizer.