### PR TITLE
Fix Last Free

### DIFF
--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -89,7 +89,6 @@ option_help * POSIX_options(void ** init_backend_options, void * init_values){
   }
 
   *init_backend_options = o;
-  free(o);
 
   option_help h [] = {
     {0, "posix.odirect", "Direct I/O Mode", OPTION_FLAG, 'd', & o->direct_io},


### PR DESCRIPTION
Fix bug introduced in #170.

Cannot get a good hold on the memory lifetime of the parsed options and the memory leaks they introduce. So I just leave them as is.