### PR TITLE
IOR: Add latency and IOPS numbers to each iteration.

### DIFF
--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -550,6 +550,17 @@ HOW DOES IOR CALCULATE PERFORMANCE?
   operations (-g), the sum of the open, transfer, and close times may not equal
   the elapsed time from the first open to the last close.
 
+  After each iteration (-i) IOR reports performance for that iteration, and
+  those numbers include:
+
+  - Bandwidth (described above)
+
+  - IOPS: I/O rate (operations per second) achieved by all tasks given the total
+    time spent in reading and writing the data.
+
+  - Latency: computed by taking the average latency of all I/O operations from a
+    single task. If ior is run with multiple tasks, then the latency reported is
+    the minimum that was computed between all tasks.
 
 HOW DO I ACCESS MULTIPLE FILE SYSTEMS IN IOR?
 

--- a/src/aiori-DAOS.c
+++ b/src/aiori-DAOS.c
@@ -241,7 +241,6 @@ DAOS_Init()
         if (rank == 0) {
                 uuid_t			uuid;
 		d_rank_list_t		*svcl = NULL;
-                d_rank_list_t    	ranks;
 		static daos_pool_info_t po_info;
 		static daos_cont_info_t co_info;
 
@@ -368,6 +367,8 @@ DAOS_Create(char *testFileName, IOR_param_t *param)
 	/** Distribute the array handle if not FPP */
 	if (!param->filePerProc)
 		HandleDistribute(&aoh, ARRAY_HANDLE);
+
+	return &aoh;
 }
 
 static int
@@ -417,6 +418,8 @@ DAOS_Open(char *testFileName, IOR_param_t *param)
 	/** Distribute the array handle if not FPP */
 	if (!param->filePerProc)
 		HandleDistribute(&aoh, ARRAY_HANDLE);
+
+	return &aoh;
 }
 
 static IOR_offset_t

--- a/src/aiori-DFS.c
+++ b/src/aiori-DFS.c
@@ -419,13 +419,12 @@ DFS_Init() {
                 if (rc == -DER_NONEXIST) {
                         INFO(VERBOSE_1, "Creating DFS Container ...\n");
 
-                        rc = daos_cont_create(poh, co_uuid, NULL, NULL);
-                        if (rc == 0) {
-                                rc = daos_cont_open(poh, co_uuid, DAOS_COO_RW,
-                                                    &coh, &co_info, NULL);
-                        }
+                        rc = dfs_cont_create(poh, co_uuid, NULL, &coh, NULL);
+                        if (rc)
+                                DCHECK(rc, "Failed to create container");
+                } else if (rc) {
+                        DCHECK(rc, "Failed to create container");
                 }
-                DCHECK(rc, "Failed to create container");
         }
 
         HandleDistribute(&poh, POOL_HANDLE);

--- a/src/ior-internal.h
+++ b/src/ior-internal.h
@@ -20,7 +20,8 @@ void PrintLongSummaryOneTest(IOR_test_t *test);
 void DisplayFreespace(IOR_param_t * test);
 void GetTestFileName(char *, IOR_param_t *);
 void PrintRemoveTiming(double start, double finish, int rep);
-void PrintReducedResult(IOR_test_t *test, int access, double bw, double *diff_subset, double totalTime, int rep);
+void PrintReducedResult(IOR_test_t *test, int access, double bw, double iops, double latency,
+			double *diff_subset, double totalTime, int rep);
 void PrintTestEnds();
 void PrintTableHeader();
 /* End of ior-output */

--- a/src/ior-output.c
+++ b/src/ior-output.c
@@ -18,8 +18,8 @@ static void PrintNextToken();
 void PrintTableHeader(){
   if (outputFormat == OUTPUT_DEFAULT){
     fprintf(out_resultfile, "\n");
-    fprintf(out_resultfile, "access    bw(MiB/s)  block(KiB) xfer(KiB)  open(s)    wr/rd(s)   close(s)   total(s) iter\n");
-    fprintf(out_resultfile, "------    ---------  ---------- ---------  --------   --------   --------   -------- ----\n");
+    fprintf(out_resultfile, "access    bw(MiB/s)  IOPS       Latency(s)  block(KiB) xfer(KiB)  open(s)    wr/rd(s)   close(s)   total(s)   iter\n");
+    fprintf(out_resultfile, "------    ---------  ----       ----------  ---------- ---------  --------   --------   --------   --------   ----\n");
   }
 }
 
@@ -219,10 +219,13 @@ void PrintTestEnds(){
   PrintEndSection();
 }
 
-void PrintReducedResult(IOR_test_t *test, int access, double bw, double *diff_subset, double totalTime, int rep){
+void PrintReducedResult(IOR_test_t *test, int access, double bw, double iops, double latency,
+			double *diff_subset, double totalTime, int rep){
   if (outputFormat == OUTPUT_DEFAULT){
     fprintf(out_resultfile, "%-10s", access == WRITE ? "write" : "read");
     PPDouble(1, bw / MEBIBYTE, " ");
+    PPDouble(1, iops, " ");
+    PPDouble(1, latency, "  ");
     PPDouble(1, (double)test->params.blockSize / KIBIBYTE, " ");
     PPDouble(1, (double)test->params.transferSize / KIBIBYTE, " ");
     PPDouble(1, diff_subset[0], " ");
@@ -772,7 +775,7 @@ void PrintRemoveTiming(double start, double finish, int rep)
     return;
 
   if (outputFormat == OUTPUT_DEFAULT){
-    fprintf(out_resultfile, "remove    -          -          -          -          -          -          ");
+    fprintf(out_resultfile, "remove    -          -          -           -          -          -          -          -          ");
     PPDouble(1, finish-start, " ");
     fprintf(out_resultfile, "%-4d\n", rep);
   }else if (outputFormat == OUTPUT_JSON){

--- a/src/ior.c
+++ b/src/ior.c
@@ -841,8 +841,9 @@ ReduceIterResults(IOR_test_t *test, double *timer, const int rep, const int acce
 {
         double reduced[IOR_NB_TIMERS] = { 0 };
         double diff[IOR_NB_TIMERS / 2 + 1];
-        double totalTime;
-        double bw;
+        double totalTime, accessTime;
+        IOR_param_t *params = &test->params;
+        double bw, iops, latency, minlatency;
         int i;
         MPI_Op op;
 
@@ -856,15 +857,12 @@ ReduceIterResults(IOR_test_t *test, double *timer, const int rep, const int acce
                                      op, 0, testComm), "MPI_Reduce()");
         }
 
-        /* Only rank 0 tallies and prints the results. */
-        if (rank != 0)
-                return;
-
         /* Calculate elapsed times and throughput numbers */
         for (i = 0; i < IOR_NB_TIMERS / 2; i++)
                 diff[i] = reduced[2 * i + 1] - reduced[2 * i];
 
         totalTime = reduced[5] - reduced[0];
+        accessTime = reduced[3] - reduced[2];
 
         IOR_point_t *point = (access == WRITE) ? &test->results[rep].write :
                                                  &test->results[rep].read;
@@ -875,7 +873,25 @@ ReduceIterResults(IOR_test_t *test, double *timer, const int rep, const int acce
                 return;
 
         bw = (double)point->aggFileSizeForBW / totalTime;
-        PrintReducedResult(test, access, bw, diff, totalTime, rep);
+
+        /* For IOPS in this iteration, we divide the total amount of IOs from
+         * all ranks over the entire access time (first start -> last end). */
+        iops = (point->aggFileSizeForBW / params->transferSize) / accessTime;
+
+        /* For Latency, we divide the total access time for each task over the
+         * number of I/Os issued from that task; then reduce and display the
+         * minimum (best) latency achieved. So what is reported is the average
+         * latency of all ops from a single task, then taking the minimum of
+         * that between all tasks. */ 
+        latency = (timer[3] - timer[2]) / (params->blockSize / params->transferSize);
+        MPI_CHECK(MPI_Reduce(&latency, &minlatency, 1, MPI_DOUBLE,
+                             MPI_MIN, 0, testComm), "MPI_Reduce()");
+
+        /* Only rank 0 tallies and prints the results. */
+        if (rank != 0)
+                return;
+
+        PrintReducedResult(test, access, bw, iops, latency, diff, totalTime, rep);
 }
 
 /*


### PR DESCRIPTION
IOR currently reports IOPS in the summary but doesn't report it per iteration. This patch adds IOPS numbers for each iteration in the output. IO Latency is also important to look at, especially for small transfer sizes. We report that too for each iteration.

- Latency reported is computed by taking the average latency of
  all ops from a single task, then taking the minimum of that
  between all tasks.

- IOPS is computed by taking the total number of ops across all
  tasks divided by the total access time to execute those ops.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>