### PR TITLE
Enable global default dir layout for subdirs in Lustre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ src/Makefile.in
 src/config.h
 src/config.h.in
 src/stamp-h1
+*[-.]mod
 *~
 NOTES.txt
 autom4te.cache

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,8 @@ AS_IF([test "x$with_lustre" = xyes ], [
                         AC_MSG_FAILURE([--with-lustre was given, <lustre/lustre_user.h> not found])
                 fi
         ])
-        AC_CHECK_HEADERS([linux/lustre/lustreapi.h lustre/lustreapi.h], break, [
+        AC_CHECK_HEADERS([linux/lustre/lustreapi.h lustre/lustreapi.h],
+		[AC_DEFINE([HAVE_LUSTRE_LUSTREAPI], [], [Lustre user API available in some shape or form])], [
                 if test "x$with_lustre" != xcheck -a \
                         "x$ac_cv_header_linux_lustre_lustreapi_h" = "xno" -a \
                         "x$ac_cv_header_lustre_lustreapi_h" = "xno" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ AC_ARG_WITH([lustre],
         [AS_HELP_STRING([--with-lustre],
                 [support configurable Lustre striping values @<:@default=check@:>@])],
         [], [with_lustre=check])
-AS_IF([test "x$with_lustre" != xno], [
+AS_IF([test "x$with_lustre" = xyes ], [
         AC_CHECK_HEADERS([linux/lustre/lustre_user.h lustre/lustre_user.h], break, [
                 if test "x$with_lustre" != xcheck -a \
                         "x$ac_cv_header_linux_lustre_lustre_user_h" = "xno" -a \
@@ -91,6 +91,17 @@ AS_IF([test "x$with_lustre" != xno], [
                         AC_MSG_FAILURE([--with-lustre was given, <lustre/lustre_user.h> not found])
                 fi
         ])
+        AC_CHECK_HEADERS([linux/lustre/lustreapi.h lustre/lustreapi.h], break, [
+                if test "x$with_lustre" != xcheck -a \
+                        "x$ac_cv_header_linux_lustre_lustreapi_h" = "xno" -a \
+                        "x$ac_cv_header_lustre_lustreapi_h" = "xno" ; then
+                        AC_MSG_FAILURE([--with-lustre was given, <lustre/lustreapi.h> not found])
+                fi
+        ])
+])
+AM_CONDITIONAL([WITH_LUSTRE], [test x$with_lustre = xyes])
+AM_COND_IF([WITH_LUSTRE],[
+        AC_DEFINE([WITH_LUSTRE], [], [Build wth LUSTRE backend])
 ])
 
 # IME (DDN's Infinite Memory Engine) support

--- a/doc/mdtest.1
+++ b/doc/mdtest.1
@@ -47,6 +47,9 @@ The first number of tasks on which the test will run
 .I "-F"
 Perform test on files only (no directories).
 .TP
+.I "-g"
+Use global default directory layout for test subdirectories (deletes inherited striping layout - Lustre only).
+.TP
 .I "-h"
 Display help message.
 .TP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,6 +91,10 @@ extraLDADD    += -laws4c
 extraLDADD    += -laws4c_extra
 endif
 
+if WITH_LUSTRE
+extraLDADD  += -llustreapi
+endif
+
 ior_SOURCES  += $(extraSOURCES)
 ior_LDFLAGS  += $(extraLDFLAGS)
 ior_LDADD    += $(extraLDADD)

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -76,9 +76,9 @@
 
 #include <mpi.h>
 
-#ifdef HAVE_LUSTRE_LUSTREAPI_H
+#ifdef HAVE_LUSTRE_LUSTREAPI
 #include <lustre/lustreapi.h>
-#endif /* HAVE_LUSTRE_LUSTREAPI_H */
+#endif /* HAVE_LUSTRE_LUSTREAPI */
 
 #define FILEMODE S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH
 #define DIRMODE S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IXOTH
@@ -156,9 +156,9 @@ static int call_sync;
 static int path_count;
 static int nstride; /* neighbor stride */
 static int make_node = 0;
-#ifdef HAVE_LUSTRE_LUSTREAPI_H
+#ifdef HAVE_LUSTRE_LUSTREAPI
 static int global_dir_layout;
-#endif /* HAVE_LUSTRE_LUSTREAPI_H */
+#endif /* HAVE_LUSTRE_LUSTREAPI */
 
 static mdtest_results_t * summary_table;
 static pid_t pid;
@@ -1582,7 +1582,7 @@ void create_remove_directory_tree(int create,
             if (-1 == backend->mkdir (dir, DIRMODE, &param)) {
                 fprintf(out_logfile, "error could not create directory '%s'\n", dir);
             }
-#ifdef HAVE_LUSTRE_LUSTREAPI_H
+#ifdef HAVE_LUSTRE_LUSTREAPI
             /* internal node for branching, can be non-striped for children */
             if (global_dir_layout && \
                 llapi_dir_set_default_lmv_stripe(dir, -1, 0,
@@ -1590,7 +1590,7 @@ void create_remove_directory_tree(int create,
                                                  NULL) == -1) {
                 FAIL("Unable to reset to global default directory layout");
             }
-#endif /* HAVE_LUSTRE_LUSTREAPI_H */
+#endif /* HAVE_LUSTRE_LUSTREAPI */
         }
 
         create_remove_directory_tree(create, ++currDepth, dir, ++dirNum, progress);
@@ -1657,12 +1657,12 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
         if (backend->mkdir(testdir, DIRMODE, &param) != 0) {
             FAIL("Unable to create test directory %s", testdir);
         }
-#ifdef HAVE_LUSTRE_LUSTREAPI_H
+#ifdef HAVE_LUSTRE_LUSTREAPI
         /* internal node for branching, can be non-striped for children */
         if (global_dir_layout && unique_dir_per_task && llapi_dir_set_default_lmv_stripe(testdir, -1, 0, LMV_HASH_TYPE_FNV_1A_64, NULL) == -1) {
             FAIL("Unable to reset to global default directory layout");
         }
-#endif /* HAVE_LUSTRE_LUSTREAPI_H */
+#endif /* HAVE_LUSTRE_LUSTREAPI */
     }
   }
 
@@ -1881,9 +1881,9 @@ void mdtest_init_args(){
    path_count = 0;
    nstride = 0;
    make_node = 0;
-#ifdef HAVE_LUSTRE_LUSTREAPI_H
+#ifdef HAVE_LUSTRE_LUSTREAPI
    global_dir_layout = 0;
-#endif /* HAVE_LUSTRE_LUSTREAPI_H */
+#endif /* HAVE_LUSTRE_LUSTREAPI */
 }
 
 mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * world_out) {
@@ -1930,9 +1930,9 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
       {'e', NULL,        "bytes to read from each file", OPTION_OPTIONAL_ARGUMENT, 'l', & read_bytes},
       {'f', NULL,        "first number of tasks on which the test will run", OPTION_OPTIONAL_ARGUMENT, 'd', & first},
       {'F', NULL,        "perform test on files only (no directories)", OPTION_FLAG, 'd', & files_only},
-#ifdef HAVE_LUSTRE_LUSTREAPI_H
+#ifdef HAVE_LUSTRE_LUSTREAPI
       {'g', NULL,        "global default directory layout for test subdirectories (deletes inherited striping layout)", OPTION_FLAG, 'd', & global_dir_layout},
-#endif /* HAVE_LUSTRE_LUSTREAPI_H */
+#endif /* HAVE_LUSTRE_LUSTREAPI */
       {'i', NULL,        "number of iterations the test will run", OPTION_OPTIONAL_ARGUMENT, 'd', & iterations},
       {'I', NULL,        "number of items per directory in tree", OPTION_OPTIONAL_ARGUMENT, 'l', & items_per_dir},
       {'k', NULL,        "use mknod to create file", OPTION_FLAG, 'd', & make_node},
@@ -2026,9 +2026,9 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     VERBOSE(1,-1, "read_only               : %s", ( read_only ? "True" : "False" ));
     VERBOSE(1,-1, "first                   : %d", first );
     VERBOSE(1,-1, "files_only              : %s", ( files_only ? "True" : "False" ));
-#ifdef HAVE_LUSTRE_LUSTREAPI_H
+#ifdef HAVE_LUSTRE_LUSTREAPI
     VERBOSE(1,-1, "global_dir_layout       : %s", ( global_dir_layout ? "True" : "False" ));
-#endif /* HAVE_LUSTRE_LUSTREAPI_H */
+#endif /* HAVE_LUSTRE_LUSTREAPI */
     VERBOSE(1,-1, "iterations              : %d", iterations );
     VERBOSE(1,-1, "items_per_dir           : "LLU"", items_per_dir );
     VERBOSE(1,-1, "last                    : %d", last );


### PR DESCRIPTION
that is, delete inherited striping layout with the invocation of a command line parameter during command execution. Feature is made available only when running configure and building with the "with-lustre" option.