### PR TITLE
added a single define for any lustre_user.h being present

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,8 @@ AC_ARG_WITH([lustre],
                 [support configurable Lustre striping values @<:@default=check@:>@])],
         [], [with_lustre=check])
 AS_IF([test "x$with_lustre" != xno], [
-        AC_CHECK_HEADERS([linux/lustre/lustre_user.h lustre/lustre_user.h], break, [
+        AC_CHECK_HEADERS([linux/lustre/lustre_user.h lustre/lustre_user.h], 
+                [AC_DEFINE([HAVE_LUSTRE_USER], [], [Lustre user API available in some shape or form])], [
                 if test "x$with_lustre" != xcheck -a \
                         "x$ac_cv_header_linux_lustre_lustre_user_h" = "xno" -a \
                         "x$ac_cv_header_lustre_lustre_user_h" = "xno" ; then

--- a/src/aiori-HDFS.c
+++ b/src/aiori-HDFS.c
@@ -76,11 +76,6 @@
 #include <fcntl.h>              /* IO operations */
 #include <sys/stat.h>
 #include <assert.h>
-/*
-#ifdef HAVE_LUSTRE_LUSTRE_USER_H
-#include <lustre/lustre_user.h>
-#endif
-*/
 
 #include "ior.h"
 #include "aiori.h"

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -335,7 +335,7 @@ void *POSIX_Create(char *testFileName, IOR_param_t * param)
         if(param->dryRun)
           return 0;
 
-#ifdef HAVE_LUSTRE_LUSTRE_USER_H
+#ifdef HAVE_LUSTRE_USER
 /* Add a #define for FASYNC if not available, as it forms part of
  * the Lustre O_LOV_DELAY_CREATE definition. */
 #ifndef FASYNC
@@ -388,7 +388,7 @@ void *POSIX_Create(char *testFileName, IOR_param_t * param)
                                           "barrier error");
                 }
         } else {
-#endif                          /* HAVE_LUSTRE_LUSTRE_USER_H */
+#endif                          /* HAVE_LUSTRE_USER */
 
                 fd_oflag |= O_CREAT | O_RDWR;
 
@@ -412,7 +412,7 @@ void *POSIX_Create(char *testFileName, IOR_param_t * param)
                         ERRF("open64(\"%s\", %d, %#o) failed",
                                 testFileName, fd_oflag, mode);
 
-#ifdef HAVE_LUSTRE_LUSTRE_USER_H
+#ifdef HAVE_LUSTRE_USER
         }
 
         if (param->lustre_ignore_locks) {
@@ -420,7 +420,7 @@ void *POSIX_Create(char *testFileName, IOR_param_t * param)
                 if (ioctl(*fd, LL_IOC_SETFLAGS, &lustre_ioctl_flags) == -1)
                         ERRF("ioctl(%d, LL_IOC_SETFLAGS, ...) failed", *fd);
         }
-#endif                          /* HAVE_LUSTRE_LUSTRE_USER_H */
+#endif                          /* HAVE_LUSTRE_USER */
 
 #ifdef HAVE_GPFS_FCNTL_H
         /* in the single shared file case, immediately release all locks, with
@@ -476,7 +476,7 @@ void *POSIX_Open(char *testFileName, IOR_param_t * param)
         if (*fd < 0)
                 ERRF("open64(\"%s\", %d) failed", testFileName, fd_oflag);
 
-#ifdef HAVE_LUSTRE_LUSTRE_USER_H
+#ifdef HAVE_LUSTRE_USER
         if (param->lustre_ignore_locks) {
                 int lustre_ioctl_flags = LL_FILE_IGNORE_LOCK;
                 if (verbose >= VERBOSE_1) {
@@ -486,7 +486,7 @@ void *POSIX_Open(char *testFileName, IOR_param_t * param)
                 if (ioctl(*fd, LL_IOC_SETFLAGS, &lustre_ioctl_flags) == -1)
                         ERRF("ioctl(%d, LL_IOC_SETFLAGS, ...) failed", *fd);
         }
-#endif                          /* HAVE_LUSTRE_LUSTRE_USER_H */
+#endif                          /* HAVE_LUSTRE_USER */
 
 #ifdef HAVE_GPFS_FCNTL_H
         if(param->gpfs_release_token) {

--- a/src/aiori-S3.c
+++ b/src/aiori-S3.c
@@ -91,11 +91,6 @@
 
 #include <errno.h>
 #include <assert.h>
-/*
-#ifdef HAVE_LUSTRE_LUSTRE_USER_H
-#include <lustre/lustre_user.h>
-#endif
-*/
 
 #include "ior.h"
 #include "aiori.h"

--- a/src/ior-output.c
+++ b/src/ior-output.c
@@ -447,13 +447,13 @@ void ShowSetup(IOR_param_t *params)
     PrintKeyValInt("dryRun", params->dryRun);
   }
 
-#ifdef HAVE_LUSTRE_LUSTRE_USER_H
+#ifdef HAVE_LUSTRE_USER
   if (params->lustre_set_striping) {
     PrintKeyVal("Lustre stripe size", ((params->lustre_stripe_size == 0) ? "Use default" :
      HumanReadable(params->lustre_stripe_size, BASE_TWO)));
     PrintKeyValInt("Lustre stripe count", params->lustre_stripe_count);
   }
-#endif /* HAVE_LUSTRE_LUSTRE_USER_H */
+#endif /* HAVE_LUSTRE_USER */
   if (params->deadlineForStonewalling > 0) {
     PrintKeyValInt("stonewallingTime", params->deadlineForStonewalling);
     PrintKeyValInt("stoneWallingWearOut", params->stoneWallingWearOut );

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -240,25 +240,25 @@ void DecodeDirective(char *line, IOR_param_t *params, options_all_t * module_opt
                 params->memoryPerNode = NodeMemoryStringToBytes(value);
                 params->memoryPerTask = 0;
         } else if (strcasecmp(option, "lustrestripecount") == 0) {
-#ifndef HAVE_LUSTRE_LUSTRE_USER_H
+#ifndef HAVE_LUSTRE_USER
                 ERR("ior was not compiled with Lustre support");
 #endif
                 params->lustre_stripe_count = atoi(value);
                 params->lustre_set_striping = 1;
         } else if (strcasecmp(option, "lustrestripesize") == 0) {
-#ifndef HAVE_LUSTRE_LUSTRE_USER_H
+#ifndef HAVE_LUSTRE_USER
                 ERR("ior was not compiled with Lustre support");
 #endif
                 params->lustre_stripe_size = string_to_bytes(value);
                 params->lustre_set_striping = 1;
         } else if (strcasecmp(option, "lustrestartost") == 0) {
-#ifndef HAVE_LUSTRE_LUSTRE_USER_H
+#ifndef HAVE_LUSTRE_USER
                 ERR("ior was not compiled with Lustre support");
 #endif
                 params->lustre_start_ost = atoi(value);
                 params->lustre_set_striping = 1;
         } else if (strcasecmp(option, "lustreignorelocks") == 0) {
-#ifndef HAVE_LUSTRE_LUSTRE_USER_H
+#ifndef HAVE_LUSTRE_USER
                 ERR("ior was not compiled with Lustre support");
 #endif
                 params->lustre_ignore_locks = atoi(value);


### PR DESCRIPTION
Fixes #189 against master.  rc and 3.2 branches will need to cherry-pick this change.