### PR TITLE
Not sure why iops and latency are left out of the JSON job output. It…

### DIFF
--- a/src/ior-output.c
+++ b/src/ior-output.c
@@ -239,6 +239,8 @@ void PrintReducedResult(IOR_test_t *test, int access, double bw, double iops, do
     PrintKeyValDouble("bwMiB", bw / MEBIBYTE);
     PrintKeyValDouble("blockKiB", (double)test->params.blockSize / KIBIBYTE);
     PrintKeyValDouble("xferKiB", (double)test->params.transferSize / KIBIBYTE);
+    PrintKeyValDouble("iops", iops);
+    PrintKeyValDouble("latency", latency);
     PrintKeyValDouble("openTime", diff_subset[0]);
     PrintKeyValDouble("wrRdTime", diff_subset[1]);
     PrintKeyValDouble("closeTime", diff_subset[2]);


### PR DESCRIPTION
… is really useful information.

Signed-off by: Robert LeBlanc <robert@leblancnet.us>