### PR TITLE
Add runpath to configure script for daos and cart

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,7 +205,7 @@ AC_ARG_WITH([cart],
 
 AS_IF([test "x$with_cart" != xno], [
     CART="yes"
-    LDFLAGS="$LDFLAGS -L$with_cart/lib"
+    LDFLAGS="$LDFLAGS -L$with_cart/lib -Wl,--enable-new-dtags -Wl,-rpath=$with_cart/lib"
     CPPFLAGS="$CPPFLAGS -I$with_cart/include/"
     AC_CHECK_HEADERS(gurt/common.h,, [unset CART])
     AC_CHECK_LIB([gurt], [d_hash_murmur64],, [unset CART])
@@ -218,7 +218,7 @@ AC_ARG_WITH([daos],
 
 AS_IF([test "x$with_daos" != xno], [
     DAOS="yes"
-    LDFLAGS="$LDFLAGS -L$with_daos/lib64 -L$with_daos/lib"
+    LDFLAGS="$LDFLAGS -L$with_daos/lib64 -Wl,--enable-new-dtags -Wl,-rpath=$with_daos/lib64"
     CPPFLAGS="$CPPFLAGS -I$with_daos/include"
     AC_CHECK_HEADERS(daos_types.h,, [unset DAOS])
     AC_CHECK_LIB([uuid], [uuid_generate],, [unset DAOS])


### PR DESCRIPTION
Enables running without setting LD_LIBRARY_PATH
Uses DT_RUNPATH (--enable-new-dtags) so that it can
be overwritten by setting LD_LIBRARY_PATH should
libraries be moved.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>