### PR TITLE
src/aiori-RADOS: Remove Direct IO option check.

### DIFF
--- a/src/aiori-RADOS.c
+++ b/src/aiori-RADOS.c
@@ -137,9 +137,6 @@ static void *RADOS_Create_Or_Open(char *testFileName, IOR_param_t * param, int c
 
         RADOS_Cluster_Init(param);
 
-        if (param->useO_DIRECT == TRUE)
-                WARN("direct I/O mode is not implemented in RADOS\n");
-
         oid = strdup(testFileName);
         if (!oid)
                 ERR("unable to allocate RADOS oid");


### PR DESCRIPTION
This param is no longer present and breaks the build when using --with-rados

Signed-off-by: Mark Nelson <mnelson@redhat.com>