### PR TITLE
DAOS Driver: Update License & Align with 1.0 API changes

### DIFF
--- a/src/aiori-DAOS.c
+++ b/src/aiori-DAOS.c
@@ -1,16 +1,9 @@
-/*
- * -*- mode: c; c-basic-offset: 8; indent-tabs-mode: nil; -*-
+/* -*- mode: c; c-basic-offset: 8; indent-tabs-mode: nil; -*-
  * vim:expandtab:shiftwidth=8:tabstop=8:
  */
 /*
- * Copyright (C) 2018-2019 Intel Corporation
- *
- * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
- * The Government's rights to use, modify, reproduce, release, perform, display,
- * or disclose this software are subject to the terms of the Apache License as
- * provided in Contract No. 8F-30005.
- * Any reproduction of computer software, computer software documentation, or
- * portions thereof marked with this legend must also reproduce the markings.
+ * Copyright (C) 2018-2020 Intel Corporation
+ * See the file COPYRIGHT for a complete copyright notice and license.
  */
 
 /*
@@ -444,10 +437,10 @@ DAOS_Xfer(int access, void *file, IOR_size_t *buffer,
 	sgl.sg_iovs = &iov;
 
         if (access == WRITE) {
-		rc = daos_array_write(aoh, DAOS_TX_NONE, &iod, &sgl, NULL, NULL);
+		rc = daos_array_write(aoh, DAOS_TX_NONE, &iod, &sgl, NULL);
                 DCHECK(rc, "daos_array_write() failed (%d).", rc);
 	} else {
-		rc = daos_array_read(aoh, DAOS_TX_NONE, &iod, &sgl, NULL, NULL);
+		rc = daos_array_read(aoh, DAOS_TX_NONE, &iod, &sgl, NULL);
                 DCHECK(rc, "daos_array_read() failed (%d).", rc);
 	}
 


### PR DESCRIPTION
- License should inherit from IOR License.
- remove checksums from Array API
- add DFS dir oclass option

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>