### PR TITLE
Display outlier host names

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -255,8 +255,13 @@ DisplayOutliers(int numTasks,
                 strcpy(accessString, "read");
         }
         if (fabs(timerVal - mean) > (double)outlierThreshold) {
-                fprintf(out_logfile, "WARNING: for task %d, %s %s is %f\n",
-                        rank, accessString, timeString, timerVal);
+                char hostname[MAX_STR];
+                int ret = gethostname(hostname, MAX_STR);
+                if (ret != 0)
+                        strcpy(hostname, "unknown");
+
+                fprintf(out_logfile, "WARNING: for %s, task %d, %s %s is %f\n",
+                        hostname, rank, accessString, timeString, timerVal);
                 fprintf(out_logfile, "         (mean=%f, stddev=%f)\n", mean, sd);
                 fflush(out_logfile);
         }


### PR DESCRIPTION
Display host names when using the -j argument (outlierThreshold) so
that IOR could help to better identify slow nodes:

WARNING: for client02, task 6, write elapsed transfer time is 65.738326