### PR TITLE
src/aiori-CEPHFS: Option warnings, shutdown checks, and cmount nullification

### DIFF
--- a/src/aiori-CEPHFS.c
+++ b/src/aiori-CEPHFS.c
@@ -125,6 +125,12 @@ static option_help * CEPHFS_options(){
 
 static void CEPHFS_Init()
 {
+        /* Short circuit if the options haven't been filled yet. */
+        if (!o.user || !o.conf || !o.prefix) {
+                WARN("CEPHFS_Init() called before options have been populated!");
+                return;
+        }
+
         /* Short circuit if the mount handle already exists */ 
         if (cmount) {
                 return;

--- a/src/aiori-CEPHFS.c
+++ b/src/aiori-CEPHFS.c
@@ -173,7 +173,15 @@ static void CEPHFS_Init()
 static void CEPHFS_Final()
 {
         /* shutdown */
-        ceph_shutdown(cmount);
+        int ret = ceph_unmount(cmount);
+        if (ret < 0) {
+		CEPHFS_ERR("ceph_umount failed", ret);
+	}
+        ret = ceph_release(cmount);
+        if (ret < 0) {
+                CEPHFS_ERR("ceph_release failed", ret);
+        }
+	cmount = NULL;
 }
 
 static void *CEPHFS_Create(char *testFileName, IOR_param_t * param)
@@ -273,7 +281,6 @@ static void CEPHFS_Close(void *file, IOR_param_t * param)
                 CEPHFS_ERR("ceph_close failed", ret);
         }
         free(file);
-
         return;
 }
 


### PR DESCRIPTION
Fixes io500 C application invocation of the aiori-CEPHFS backend so long as the API is set in the individual benchmark sections rather than globally.  It also throws a WARN if Init is called before the options are initialized (which is what IO500 tries to do currently if you set the API globally in the ini file).