### PR TITLE
mdtest: allocate aligned buffers to support DirectIO

### DIFF
--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -633,8 +633,8 @@ void mdtest_read(int random, int dirs, const long dir_iter, char *path) {
 
     /* allocate read buffer */
     if (read_bytes > 0) {
-        read_buffer = (char *)malloc(read_bytes);
-        if (read_buffer == NULL) {
+        int alloc_res = posix_memalign((void**)&read_buffer, sysconf(_SC_PAGESIZE), write_bytes);
+        if (alloc_res) {
             FAIL("out of memory");
         }
 
@@ -2125,8 +2125,8 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
 
     /* allocate and initialize write buffer with # */
     if (write_bytes > 0) {
-        write_buffer = (char *)malloc(write_bytes);
-        if (write_buffer == NULL) {
+        int alloc_res = posix_memalign((void**)&write_buffer, sysconf(_SC_PAGESIZE), write_bytes);
+        if (alloc_res) {
             FAIL("out of memory");
         }
         generate_memory_pattern(write_buffer, write_bytes);


### PR DESCRIPTION
`mdtest --posix.odirect` was not working and failed with "Invalid argument" on write/read (e.g. on RHEL7 for xfs/BeeGFS/NFS), because the corresponding memory buffers for write/read were not correctly aligned. According to `man 2 open`, "The O_DIRECT flag may impose alignment restrictions on the length and address of user-space buffers". This patch fixes DirectIO support by allocating page-aligned write and read buffers via `posix_memalign`.