### PR TITLE
MDTest changed verification pattern. 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@ if USE_CAPS
 bin_PROGRAMS += IOR MDTEST
 endif
 
-noinst_HEADERS = ior.h utilities.h parse_options.h aiori.h iordef.h ior-internal.h option.h mdtest.h
+noinst_HEADERS = ior.h utilities.h parse_options.h aiori.h iordef.h ior-internal.h option.h mdtest.h aiori-debug.h
 
 lib_LIBRARIES = libaiori.a
 libaiori_a_SOURCES = ior.c mdtest.c utilities.c parse_options.c ior-output.c option.c

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1994,6 +1994,8 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     backend = aiori_select(api);
     if (backend == NULL)
         ERR("Unrecognized I/O API");
+    if (! backend->enable_mdtest)
+        ERR("Backend doesn't support MDTest");
     backend_options = airoi_update_module_options(backend, global_options);
 
     free(global_options->modules);


### PR DESCRIPTION
Read now always checks the first byte/8 bytes for the signature (item number).
This should increase the robustness again broken systems.

Added also --verify-write option which performs a read immediately after a write. Supports #206