### PR TITLE
HDF5: fix segfault in HDF5 driver after latest AIORI changes

### DIFF
--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -171,6 +171,8 @@ static aiori_xfer_hint_t * hints = NULL;
 
 static void HDF5_init_xfer_options(aiori_xfer_hint_t * params){
   hints = params;
+  /** HDF5 utilizes the MPIIO backend too, so init hints there */
+  MPIIO_xfer_hints(params);
 }
 
 static int HDF5_check_params(aiori_mod_opt_t * options){

--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -40,7 +40,6 @@ static IOR_offset_t MPIIO_Xfer(int, aiori_fd_t *, IOR_size_t *,
 static void MPIIO_Close(aiori_fd_t *, aiori_mod_opt_t *);
 static char* MPIIO_GetVersion();
 static void MPIIO_Fsync(aiori_fd_t *, aiori_mod_opt_t *);
-static void MPIIO_xfer_hints(aiori_xfer_hint_t * params);
 static int MPIIO_check_params(aiori_mod_opt_t * options);
 
 /************************** D E C L A R A T I O N S ***************************/
@@ -108,7 +107,7 @@ ior_aiori_t mpiio_aiori = {
 /***************************** F U N C T I O N S ******************************/
 static aiori_xfer_hint_t * hints = NULL;
 
-static void MPIIO_xfer_hints(aiori_xfer_hint_t * params){
+void MPIIO_xfer_hints(aiori_xfer_hint_t * params){
   hints = params;
 }
 
@@ -140,10 +139,10 @@ static int MPIIO_check_params(aiori_mod_opt_t * module_options){
  */
 int MPIIO_Access(const char *path, int mode, aiori_mod_opt_t *module_options)
 {
-    mpiio_options_t * param = (mpiio_options_t*) module_options;
     if(hints->dryRun){
       return MPI_SUCCESS;
     }
+    mpiio_options_t * param = (mpiio_options_t*) module_options;
     MPI_File fd;
     int mpi_mode = MPI_MODE_UNIQUE_OPEN;
     MPI_Info mpiHints = MPI_INFO_NULL;

--- a/src/aiori.h
+++ b/src/aiori.h
@@ -157,9 +157,10 @@ int aiori_posix_access (const char *path, int mode, aiori_mod_opt_t * module_opt
 int aiori_posix_stat (const char *path, struct stat *buf, aiori_mod_opt_t * module_options);
 
 
-/* NOTE: these 3 MPI-IO functions are exported for reuse by HDF5/PNetCDF */
+/* NOTE: these 4 MPI-IO functions are exported for reuse by HDF5/PNetCDF */
 void MPIIO_Delete(char *testFileName, aiori_mod_opt_t * module_options);
 IOR_offset_t MPIIO_GetFileSize(aiori_mod_opt_t * options, char *testFileName);
 int MPIIO_Access(const char *, int, aiori_mod_opt_t * module_options);
+void MPIIO_xfer_hints(aiori_xfer_hint_t * params);
 
 #endif /* not _AIORI_H */


### PR DESCRIPTION
- the hints structure was not getting initialized in MPIIO when HDF5
backend is used. Since HDF5 utilizes the MPIIO backend, this causes
a segfault.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>