### PR TITLE
aiori-IME: Fix init after finalize issue

### DIFF
--- a/src/aiori-IME.c
+++ b/src/aiori-IME.c
@@ -160,7 +160,7 @@ void IME_Finalize()
                 return;
 
         (void)ime_native_finalize();
-        ime_initialized = true;
+        ime_initialized = false;
 }
 
 /*


### PR DESCRIPTION
ime_initialized global variable is not reset after having called ime_native_finalize.  