### PR TITLE
Fix JSON output format of IOR using repeating option

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1529,8 +1529,8 @@ static void TestIoSys(IOR_test_t *test)
                 params->errorFound = FALSE;
                 rankOffset = 0;
 
-                PrintRepeatEnd();
         }
+        PrintRepeatEnd();
 
         MPI_CHECK(MPI_Comm_free(&testComm), "MPI_Comm_free() error");
 


### PR DESCRIPTION
Hi,

I got some invalid JSON format output of IOR results with using `-i N (N > 1)` option, 
so I fix it in this commit.

### test
small test result by `jsonlint` command bellow:

```sh
$ ior -i 2 -O summaryFormat=JSON -O summaryFile=$(pwd)/testIOR.json -b 1m -t 128k
$ jsonlint testIOR.json
testIOR.json:149:4: Warning: Object contains duplicate key: 'segmentCount'
   |  At line 149, column 4, offset 3858
   |  Object started at line 133, column 4, offset 3472
testIOR.json:150:4: Warning: Object contains duplicate key: 'blockSize'
   |  At line 150, column 4, offset 3882
   |  Object started at line 133, column 4, offset 3472
testIOR.json:151:4: Warning: Object contains duplicate key: 'transferSize'
   |  At line 151, column 4, offset 3909
   |  Object started at line 133, column 4, offset 3472
testIOR.json:180:4: Warning: Object contains duplicate key: 'segmentCount'
   |  At line 180, column 4, offset 4589
   |  Object started at line 164, column 4, offset 4204
testIOR.json:181:4: Warning: Object contains duplicate key: 'blockSize'
   |  At line 181, column 4, offset 4613
   |  Object started at line 164, column 4, offset 4204
testIOR.json:182:4: Warning: Object contains duplicate key: 'transferSize'
   |  At line 182, column 4, offset 4640
   |  Object started at line 164, column 4, offset 4204
testIOR.json: ok, with warnings
```