### PR TITLE
Fix offset integration

### DIFF
--- a/src/aiori.c
+++ b/src/aiori.c
@@ -128,6 +128,8 @@ void aiori_supported_apis(char * APIs, char * APIs_legacy, enum bench_type type)
 {
         ior_aiori_t **tmp = available_aiori;
         char delimiter = ' ';
+        *APIs = 0;
+        *APIs_legacy = 0;
 
         while (*tmp != NULL)
         {
@@ -136,7 +138,6 @@ void aiori_supported_apis(char * APIs, char * APIs_legacy, enum bench_type type)
                     tmp++;
                     continue;
                 }
-
                 if (delimiter == ' ')
                 {
                         APIs += sprintf(APIs, "%s", (*tmp)->name);
@@ -148,6 +149,7 @@ void aiori_supported_apis(char * APIs, char * APIs_legacy, enum bench_type type)
                 if ((*tmp)->name_legacy != NULL)
                         APIs_legacy += sprintf(APIs_legacy, "%c%s",
                                                delimiter, (*tmp)->name_legacy);
+
                 tmp++;
         }
 }

--- a/src/ior-internal.h
+++ b/src/ior-internal.h
@@ -25,7 +25,7 @@ void PrintTestEnds();
 void PrintTableHeader();
 /* End of ior-output */
 
-IOR_offset_t *GetOffsetArrayRandom(IOR_param_t * test, int pretendRank);
+IOR_offset_t *GetOffsetArrayRandom(IOR_param_t * test, int pretendRank, IOR_offset_t * out_count);
 
 struct results {
   double min;

--- a/src/ior-internal.h
+++ b/src/ior-internal.h
@@ -25,8 +25,7 @@ void PrintTestEnds();
 void PrintTableHeader();
 /* End of ior-output */
 
-IOR_offset_t *GetOffsetArraySequential(IOR_param_t * test, int pretendRank);
-IOR_offset_t *GetOffsetArrayRandom(IOR_param_t * test, int pretendRank, int access);
+IOR_offset_t *GetOffsetArrayRandom(IOR_param_t * test, int pretendRank);
 
 struct results {
   double min;

--- a/src/ior.c
+++ b/src/ior.c
@@ -1849,14 +1849,16 @@ static IOR_offset_t WriteOrRead(IOR_param_t *test, IOR_results_t *results,
           if(rank == 0 && verbose > VERBOSE_1){
             fprintf(out_logfile, "Random prefill took: %fs\n", GetTimeStamp() - t_start);
           }
+          // must synchronize processes to ensure they are not running ahead
+          MPI_Barrier(test->testComm);
         }
 
         for (i = 0; i < test->segmentCount && !hitStonewall; i++) {
           if(randomPrefillBuffer && test->deadlineForStonewalling != 0){
             // prefill the whole segment with data, this needs to be done collectively
             double t_start = GetTimeStamp();
-            MPI_Barrier(test->testComm);
             prefillSegment(test, randomPrefillBuffer, pretendRank, fd, ioBuffers, i, i+1);
+            MPI_Barrier(test->testComm);
             if(rank == 0 && verbose > VERBOSE_1){
               fprintf(out_logfile, "Random: synchronizing segment count with barrier and prefill took: %fs\n", GetTimeStamp() - t_start);
             }

--- a/src/ior.c
+++ b/src/ior.c
@@ -1586,6 +1586,8 @@ static void ValidateTests(IOR_param_t * test)
         }
         if (test->blockSize < test->transferSize)
                 ERR("block size must not be smaller than transfer size");
+        if (test->randomOffset && test->blockSize == test->transferSize)
+            ERR("IOR will randomize access within a block and repeats the same pattern for all segments, therefore choose blocksize > transferSize");
 
         /* specific APIs */
         if ((strcasecmp(test->api, "MPIIO") == 0)

--- a/src/ior.h
+++ b/src/ior.h
@@ -127,6 +127,7 @@ typedef struct
     IOR_offset_t blockSize;          /* contiguous bytes to write per task */
     IOR_offset_t transferSize;       /* size of transfer in bytes */
     IOR_offset_t expectedAggFileSize; /* calculated aggregate file size */
+    IOR_offset_t randomPrefillBlocksize;   /* prefill option for random IO, the amount of data used for prefill */
 
     int summary_every_test;          /* flag to print summary every test, not just at end */
     int uniqueDir;                   /* use unique directory for each fpp */
@@ -168,7 +169,7 @@ typedef struct
     int         hdfs_block_size;     /* internal blk-size. (0 gets default) */
 
     char*       URI;                 /* "path" to target object */
-    
+
     /* RADOS variables */
     rados_t rados_cluster;           /* RADOS cluster handle */
     rados_ioctx_t rados_ioctx;       /* I/O context for our pool in the RADOS cluster */

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -384,7 +384,7 @@ option_help * createGlobalOptions(IOR_param_t * params){
   char APIs[1024];
   char APIs_legacy[1024];
   aiori_supported_apis(APIs, APIs_legacy, IOR);
-  char apiStr[1024];
+  char * apiStr = safeMalloc(1024);
   sprintf(apiStr, "API for I/O [%s]", APIs);
 
   option_help o [] = {

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -433,6 +433,7 @@ option_help * createGlobalOptions(IOR_param_t * params){
     {'y', NULL,        "dualMount -- use dual mount points for a filesystem", OPTION_FLAG, 'd', & params->dualMount},
     {'Y', NULL,        "fsyncPerWrite -- perform sync operation after every write operation", OPTION_FLAG, 'd', & params->fsyncPerWrite},
     {'z', NULL,        "randomOffset -- access is to random, not sequential, offsets within a file", OPTION_FLAG, 'd', & params->randomOffset},
+    {0, "randomPrefill", "For random -z access only: Prefill the file with this blocksize, e.g., 2m", OPTION_OPTIONAL_ARGUMENT, 'l', & params->randomPrefillBlocksize},
     {0, "random-offset-seed",        "The seed for -z", OPTION_OPTIONAL_ARGUMENT, 'd', & params->randomSeed},
     {'Z', NULL,        "reorderTasksRandom -- changes task ordering to random ordering for readback", OPTION_FLAG, 'd', & params->reorderTasksRandom},
     {0, "warningAsErrors",        "Any warning should lead to an error.", OPTION_FLAG, 'd', & params->warningAsErrors},

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -655,27 +655,6 @@ int Regex(char *string, char *pattern)
 }
 
 /*
- * Seed random generator.
- */
-void SeedRandGen(MPI_Comm testComm)
-{
-        unsigned int randomSeed;
-
-        if (rank == 0) {
-#ifdef _WIN32
-                rand_s(&randomSeed);
-#else
-                struct timeval randGenTimer;
-                gettimeofday(&randGenTimer, (struct timezone *)NULL);
-                randomSeed = randGenTimer.tv_usec;
-#endif
-        }
-        MPI_CHECK(MPI_Bcast(&randomSeed, 1, MPI_INT, 0,
-                            testComm), "cannot broadcast random seed value");
-        srandom(randomSeed);
-}
-
-/*
  * System info for Windows.
  */
 #ifdef _WIN32

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -46,7 +46,6 @@ char *CurrentTimeString(void);
 int Regex(char *, char *);
 void ShowFileSystemSize(IOR_param_t * test);
 void DumpBuffer(void *, size_t);
-void SeedRandGen(MPI_Comm);
 void SetHints (MPI_Info *, char *);
 void ShowHints (MPI_Info *);
 char *HumanReadable(IOR_offset_t value, int base);

--- a/testing/basic-tests.sh
+++ b/testing/basic-tests.sh
@@ -16,15 +16,17 @@ MDTEST 2 -a POSIX -W 2
 MDTEST 1 -C -T -r -F -I 1 -z 1 -b 1 -L -u
 MDTEST 1 -C -T -I 1 -z 1 -b 1 -u
 
-IOR 1 -a POSIX -w    -z                  -F -Y -e -i1 -m -t 100k -b 1000k
-IOR 1 -a POSIX -w    -z                  -F -k -e -i2 -m -t 100k -b 100k
-IOR 1 -a MMAP -r    -z                  -F -k -e -i1 -m -t 100k -b 100k
+IOR 1 -a POSIX -w    -z                  -F -Y -e -i1 -m -t 100k -b 2000k
+IOR 1 -a POSIX -w    -z                  -F -k -e -i2 -m -t 100k -b 200k
+IOR 1 -a MMAP -r    -z                  -F -k -e -i1 -m -t 100k -b 200k
 
-IOR 2 -a POSIX -w    -z  -C             -F -k -e -i1 -m -t 100k -b 100k
-IOR 2 -a POSIX -w    -z  -C -Q 1        -F -k -e -i1 -m -t 100k -b 100k
-IOR 2 -a POSIX -r    -z  -Z -Q 2        -F -k -e -i1 -m -t 100k -b 100k
-IOR 2 -a POSIX -r    -z  -Z -Q 3 -X  13 -F -k -e -i1 -m -t 100k -b 100k
-IOR 2 -a POSIX -w    -z  -Z -Q 1 -X -13 -F    -e -i1 -m -t 100k -b 100k
+IOR 2 -a POSIX -w     -C              -k -e -i1 -m -t 100k -b 200k
+
+IOR 2 -a POSIX -w    -z  -C             -F -k -e -i1 -m -t 100k -b 200k
+IOR 2 -a POSIX -w    -z  -C -Q 1        -F -k -e -i1 -m -t 100k -b 200k
+IOR 2 -a POSIX -r    -z  -Z -Q 2        -F -k -e -i1 -m -t 100k -b 200k
+IOR 2 -a POSIX -r    -z  -Z -Q 3 -X  13 -F -k -e -i1 -m -t 100k -b 200k
+IOR 2 -a POSIX -w    -z  -Z -Q 1 -X -13 -F    -e -i1 -m -t 100k -b 200k
 
 IOR 2 -f "$ROOT/test_comments.ior"
 

--- a/testing/test_comments.ior
+++ b/testing/test_comments.ior
@@ -2,16 +2,16 @@
 IOR START
 api=posix
 writeFile =1
-    randomOffset=1
+   randomOffset=1
 reorderTasks=1
-  filePerProc=1
+   filePerProc=1
 		keepFile=1
 fsync=1
 	repetitions=1
 multiFile=1
 		# tab-prefixed comment
-transferSize=100k
-blockSize=100k
+transferSize=10k
+blockSize=20k
     # space-prefixed comment
 run
 --dummy.delay-create=1000


### PR DESCRIPTION
This series of patches addresses #219.
The behavior of the offset creation had been changed as follows:
- there is no need to create the array of all file offsets any more
- for sequential IO, the offset calculation is part of the loops
- for random IO, the random offset calculation is done as before but only within *one* block providing some meaning to the semantics of block, transfer size, and segments. Before the blocks were meaningless for random.

Now: the segments repeat the same random pattern.

Consider the example for 1 process:
-t 4096 -b 40960 -s 2
There are 10 random positions between offsets 0, 4k, up to 36k, this pattern is repeated two times (offset by 40kb in the second iteration).

When more than 1 process takes place, it depends on if it is file per process or shared file.
For FPP, each process will now have its own random pool for a block, otherwise similar to 1 process case.
For shared file, the randomness is number of processes * block and the overall pattern is randomized in this larger area -- this behavior is as it was before. However, the same pattern repeats then for each segment.

To imitate the old behavior, one can set -s=1 and use a large block size. 
To create for example a random pattern that effects a range of 4 MByte and then repeats 10x, use:
-t 4096 -b 4m -s 10

This allows now to reduce the pressure of storing offsets for random while it still gives the flexibility to control what's happening.