### PR TITLE
Bugfix S3: suboptimal name mapping was leading to accidential deletes in md-workbench.

### DIFF
--- a/src/aiori-S3-libs3.c
+++ b/src/aiori-S3-libs3.c
@@ -86,9 +86,14 @@ static void def_file_name(s3_options_t * o, char * out_name, char const * path){
     }else if(c >= 'A' && c <= 'Z'){
       *out_name = *path + ('a' - 'A');
       out_name++;
+    }else if(c == '/'){
+      *out_name = '_';
+      out_name++;
     }
     path++;
   }
+  *out_name = '-';
+  out_name++;
   *out_name = '\0';
 }
 


### PR DESCRIPTION
The file mapping created object names such as:
out00file1
out00file2
...
out00file11
From the source filename:
./out/0_0/file-1

Without bucket mapping, this caused the deletion of ./out/0_0/file-1 to delete objects such as out00file11.
Now the filenames map / to _ and are all suffixed with "-" 
example: _out_00_file1-
This prevents the issue as there is no common suffix.