### PR TITLE
Refactoring: MDTest

### DIFF
--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -149,7 +149,6 @@ typedef struct {
   int pre_delay;
   int unique_dir_per_task;
   int time_unique_dir_overhead;
-  int throttle;
   int collective_creates;
   size_t write_bytes;
   int stone_wall_timer_seconds;
@@ -1885,7 +1884,6 @@ void mdtest_init_args(){
    memset(& o, 0, sizeof(o));
    o.barriers = 1;
    o.branch_factor = 1;
-   o.throttle = 1;
 }
 
 mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * world_out) {

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -76,6 +76,8 @@
 
 #include <mpi.h>
 
+#pragma GCC diagnostic ignored "-Wformat-overflow"
+
 #ifdef HAVE_LUSTRE_LUSTREAPI
 #include <lustre/lustreapi.h>
 #endif /* HAVE_LUSTRE_LUSTREAPI */

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1522,6 +1522,8 @@ void md_validate_tests() {
          FAIL("only specify the number of items or the number of items per directory");
        }else if( o.items % o.items_per_dir != 0){
          FAIL("items must be a multiple of items per directory");
+       }else if( o.stone_wall_timer_seconds != 0){
+         FAIL("items + items_per_dir can only be set without stonewalling");
        }
     }
     /* check for using mknod */

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1046,8 +1046,7 @@ int updateStoneWallIterations(int iteration, uint64_t items_done, double tstart,
 
 void file_test_create(const int iteration, const int ntasks, const char *path, rank_progress_t * progress, double *t){
   char temp_path[MAX_PATHLEN];
-  int cur_dir_loops = o.directory_loops;
-  for (int dir_iter = 0; dir_iter < cur_dir_loops; dir_iter ++){
+  for (int dir_iter = 0; dir_iter < o.directory_loops; dir_iter ++){
     prep_testdir(iteration, dir_iter);
 
     if (o.unique_dir_per_task) {
@@ -1091,6 +1090,7 @@ void file_test_create(const int iteration, const int ntasks, const char *path, r
       }
       // reset stone wall timer to allow proper cleanup
       progress->stone_wall_timer_seconds = 0;
+      // at the moment, stonewall can be done only with one directory_loop, so we can return here safely
       break;
     }
   }
@@ -1881,9 +1881,10 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
 }
 
 void mdtest_init_args(){
-   memset(& o, 0, sizeof(o));
-   o.barriers = 1;
-   o.branch_factor = 1;
+  o = (mdtest_options_t) {
+     .barriers = 1,
+     .branch_factor = 1
+  };
 }
 
 mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * world_out) {


### PR DESCRIPTION
This PR refactors the 50+ static variables to be part of a global option structure to remove ambiguity in which scope the variable is.

In the code, there is at the moment too much dependency to global variables.
Ultimately, the goal was to make stonewalling work with the multi-dir approach but it turned out this requires much more refactoring and therefore, doing it piece by piece.
