### PR TITLE
mdtest: fix reference to unique_dir_per_task for builds --with-lustre

### DIFF
--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1708,7 +1708,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
         }
 #ifdef HAVE_LUSTRE_LUSTREAPI
         /* internal node for branching, can be non-striped for children */
-        if (o.global_dir_layout && unique_dir_per_task && llapi_dir_set_default_lmv_stripe(o.testdir, -1, 0, LMV_HASH_TYPE_FNV_1A_64, NULL) == -1) {
+        if (o.global_dir_layout && o.unique_dir_per_task && llapi_dir_set_default_lmv_stripe(o.testdir, -1, 0, LMV_HASH_TYPE_FNV_1A_64, NULL) == -1) {
             FAIL("Unable to reset to global default directory layout");
         }
 #endif /* HAVE_LUSTRE_LUSTREAPI */


### PR DESCRIPTION
When code was refactored to eliminate global vars, there was a reference to unique_dir_per_task that was not updated.  This only affects builds using --with-lustre.