### PR TITLE
Do not execute functions twice in MPI_CHECKF

### DIFF
--- a/src/aiori-debug.h
+++ b/src/aiori-debug.h
@@ -94,12 +94,13 @@ extern int aiori_warning_as_errors;
 #define MPI_CHECKF(MPI_STATUS, FORMAT, ...) do {                         \
     char resultString[MPI_MAX_ERROR_STRING];                             \
     int resultLength;                                                    \
+    int checkf_mpi_status = MPI_STATUS;                                  \
                                                                          \
-    if (MPI_STATUS != MPI_SUCCESS) {                                     \
-        MPI_Error_string(MPI_STATUS, resultString, &resultLength);       \
-        fprintf(out_logfile, "ERROR: " FORMAT ", MPI %s, (%s:%d)\n",      \
+    if (checkf_mpi_status != MPI_SUCCESS) {                              \
+        MPI_Error_string(checkf_mpi_status, resultString, &resultLength);\
+        fprintf(out_logfile, "ERROR: " FORMAT ", MPI %s, (%s:%d)\n",     \
                 __VA_ARGS__, resultString, __FILE__, __LINE__);          \
-        fflush(out_logfile);                                                  \
+        fflush(out_logfile);                                             \
         MPI_Abort(MPI_COMM_WORLD, -1);                                   \
     }                                                                    \
 } while(0)


### PR DESCRIPTION
Assigning MPI_STATUS to a local variable and then referring to the
local will ensure that the same value is used in both the conditional
expression and the call to MPI_Error_string.

Otherwise, when MPI_STATUS is a function call, like

  MPI_CHECKF(fubar(), "%s", "error in fubar");

fubar() is called twice.  If there are underlying intermittent errors,
the error code/message for the first call is lost, with confusing output
like this:

  read      2206.18    17.27      145.93      262144     131072
  0.272595   291.88     0.290829   292.41
  ERROR: cannot access explicit, noncollective, MPI MPI_SUCCESS: no errors, (aiori-MPIIO.c:451)