### PR TITLE
Fix calc stonewall

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1918,14 +1918,14 @@ static IOR_offset_t WriteOrRead(IOR_param_t *test, IOR_results_t *results,
                                   1, MPI_LONG_LONG_INT, MPI_MIN, 0, testComm), "cannot reduce pairs moved");
           MPI_CHECK(MPI_Reduce(& data_moved_ll, &point->stonewall_min_data_accessed,
                                   1, MPI_LONG_LONG_INT, MPI_MIN, 0, testComm), "cannot reduce pairs moved");
-          MPI_CHECK(MPI_Reduce(& data_moved_ll, &point->stonewall_avg_data_accessed,
+          MPI_CHECK(MPI_Reduce(& data_moved_ll, &point->stonewall_total_data_accessed,
                                   1, MPI_LONG_LONG_INT, MPI_SUM, 0, testComm), "cannot reduce pairs moved");
 
           if(rank == 0){
+            point->stonewall_avg_data_accessed = point->stonewall_total_data_accessed / test->numTasks;
             fprintf(out_logfile, "stonewalling pairs accessed min: %lld max: %zu -- min data: %.1f GiB mean data: %.1f GiB time: %.1fs\n",
              pairs_accessed_min, point->pairs_accessed,
-             point->stonewall_min_data_accessed /1024.0 / 1024 / 1024, point->stonewall_avg_data_accessed / 1024.0 / 1024 / 1024 / test->numTasks , point->stonewall_time);
-             point->stonewall_min_data_accessed *= test->numTasks;
+             point->stonewall_min_data_accessed /1024.0 / 1024 / 1024, point->stonewall_avg_data_accessed / 1024.0 / 1024 / 1024 , point->stonewall_time);
           }
           if(pairCnt != point->pairs_accessed){
             // some work needs still to be done !

--- a/src/ior.c
+++ b/src/ior.c
@@ -1292,7 +1292,7 @@ static void TestIoSys(IOR_test_t *test)
         uint64_t params_saved_wearout = params->stoneWallingWearOutIterations;
 
         /* Check if the file exists and warn users */
-        if( params->hints.filePerProc || rank == 0){
+        if((params->writeFile || params->checkWrite) && (params->hints.filePerProc || rank == 0)){
           struct stat sb;
           GetTestFileName(testFileName, params);
           int ret = backend->stat(testFileName, & sb, params->backend_options);

--- a/src/ior.h
+++ b/src/ior.h
@@ -190,8 +190,9 @@ typedef struct {
    size_t pairs_accessed; // number of I/Os done, useful for deadlineForStonewalling
 
    double     stonewall_time;
-   long long  stonewall_min_data_accessed;
-   long long  stonewall_avg_data_accessed;
+   long long  stonewall_min_data_accessed; // of all processes
+   long long  stonewall_avg_data_accessed; // across all processes
+   long long  stonewall_total_data_accessed; // sum accross all processes
 
    IOR_offset_t aggFileSizeFromStat;
    IOR_offset_t aggFileSizeFromXfer;


### PR DESCRIPTION
The calculation in the API was missleading.
Average across processes vs. total = sum.