### PR TITLE
aiori-DFS: stat should not be fatal

### DIFF
--- a/src/aiori-DFS.c
+++ b/src/aiori-DFS.c
@@ -945,7 +945,6 @@ DFS_Stat(const char *path, struct stat *buf, aiori_mod_opt_t * param)
                 GERR("Failed to lookup parent dir");
 
 	rc = dfs_stat(dfs, parent, name, buf);
-        DCHECK(rc, "dfs_stat() of Failed (%d)", rc);
 
 	if (name)
 		free(name);


### PR DESCRIPTION
ior now expects stat to not be fatal. update the DFS driver to not
exit if stat fails since the file can simply not exist.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>