### PR TITLE
IOR: move verbose output of detailed errors to verbosity level 1.

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -435,7 +435,7 @@ CompareData(void *expectedBuffer, size_t size, IOR_offset_t transferCount, IOR_p
                         fprintf(out_logfile, "\n");
                 }
         }
-        if (errorCount > 0) {
+        if (errorCount > 0 && verbose >= VERBOSE_1) {
                 GetTestFileName(testFileName, test);
                 EWARNF("[%d] FAILED comparison of buffer in file %s during transfer %lld offset %lld containing %d-byte ints (%zd errors)",
                         rank, testFileName, transferCount, offset, (int)sizeof(unsigned long long int),errorCount);


### PR DESCRIPTION
IOR by default outputs the numbers of errors.
Reason: The number of error messages can be overwhelming, particularly in a parallel program (Gigabytes...).
One -v increases the verbosity level to provide the extra details without adding too many other messages.