### PR TITLE
Remove MPI timer in favor of gettimeofday() to prevent MPI timing issues. 

### DIFF
--- a/src/ior-output.c
+++ b/src/ior-output.c
@@ -304,23 +304,6 @@ void PrintHeader(int argc, char **argv)
                 }
                 PrintKeyValEnd();
         }
-
-#ifdef _NO_MPI_TIMER
-        if (verbose >= VERBOSE_2)
-                fprintf(out_logfile, "Using unsynchronized POSIX timer\n");
-#else                           /* not _NO_MPI_TIMER */
-        if (MPI_WTIME_IS_GLOBAL) {
-                if (verbose >= VERBOSE_2)
-                    fprintf(out_logfile, "Using synchronized MPI timer\n");
-        } else {
-                if (verbose >= VERBOSE_2)
-                  fprintf(out_logfile, "Using unsynchronized MPI timer\n");
-        }
-#endif                          /* _NO_MPI_TIMER */
-        if (verbose >= VERBOSE_1) {
-                fprintf(out_logfile, "Start time skew across all tasks: %.02f sec\n",
-                        wall_clock_deviation);
-        }
         if (verbose >= VERBOSE_3) {     /* show env */
                 fprintf(out_logfile, "STARTING ENVIRON LOOP\n");
                 for (i = 0; environ[i] != NULL; i++) {

--- a/src/ior.c
+++ b/src/ior.c
@@ -244,7 +244,7 @@ DisplayOutliers(int numTasks,
         double sum, mean, sqrDiff, var, sd;
 
         /* for local timerVal, don't compensate for wall clock delta */
-        timerVal += wall_clock_delta;
+        //timerVal += wall_clock_delta;
 
         MPI_CHECK(MPI_Allreduce
                   (&timerVal, &sum, 1, MPI_DOUBLE, MPI_SUM, testComm),

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -673,10 +673,6 @@ int uname(struct utsname *name)
 }
 #endif /* _WIN32 */
 
-
-double wall_clock_deviation;
-double wall_clock_delta = 0;
-
 /*
  * Get time stamp.  Use MPI_Timer() unless _NO_MPI_TIMER is defined,
  * in which case use gettimeofday().
@@ -684,26 +680,18 @@ double wall_clock_delta = 0;
 double GetTimeStamp(void)
 {
         double timeVal;
-#ifdef _NO_MPI_TIMER
         struct timeval timer;
 
         if (gettimeofday(&timer, (struct timezone *)NULL) != 0)
                 ERR("cannot use gettimeofday()");
         timeVal = (double)timer.tv_sec + ((double)timer.tv_usec / 1000000);
-#else                           /* not _NO_MPI_TIMER */
-        timeVal = MPI_Wtime();  /* no MPI_CHECK(), just check return value */
-        if (timeVal < 0)
-                ERR("cannot use MPI_Wtime()");
-#endif                          /* _NO_MPI_TIMER */
-
-        /* wall_clock_delta is difference from root node's time */
-        timeVal -= wall_clock_delta;
 
         return (timeVal);
 }
 
 /*
  * Determine any spread (range) between node times.
+ * Obsolete
  */
 static double TimeDeviation(MPI_Comm com)
 {
@@ -725,14 +713,13 @@ static double TimeDeviation(MPI_Comm com)
         roottimestamp = timestamp;
         MPI_CHECK(MPI_Bcast(&roottimestamp, 1, MPI_DOUBLE, 0, com),
                   "cannot broadcast root's time");
-        wall_clock_delta = timestamp - roottimestamp;
+        // wall_clock_delta = timestamp - roottimestamp;
 
         return max - min;
 }
 
 void init_clock(MPI_Comm com){
-  /* check for skew between tasks' start times */
-  wall_clock_deviation = TimeDeviation(com);
+
 }
 
 char * PrintTimestamp() {

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -59,6 +59,4 @@ double GetTimeStamp(void);
 char * PrintTimestamp(); // TODO remove this function
 unsigned long GetProcessorAndCore(int *chip, int *core);
 
-extern double wall_clock_deviation;
-extern double wall_clock_delta;
 #endif  /* !_UTILITIES_H */


### PR DESCRIPTION
Remove time adjustment as measurements are relative anyway.