### PR TITLE
MDTest data verification improvements.

### DIFF
--- a/src/md-workbench.c
+++ b/src/md-workbench.c
@@ -116,6 +116,7 @@ struct benchmark_options{
   int rank;
   int size;
   int verify_read;
+  int random_buffer_offset;
 
   float relative_waiting_factor;
   int adaptive_waiting_mode;
@@ -134,16 +135,17 @@ static void def_obj_name(char * out_name, int n, int d, int i){
 }
 
 void init_options(){
-  memset(& o, 0, sizeof(o));
-  o.interface = "POSIX";
-  o.prefix = "./out";
-  o.num = 1000;
-  o.precreate = 3000;
-  o.dset_count = 10;
-  o.offset = 1;
-  o.iterations = 3;
-  o.file_size = 3901;
-  o.run_info_file = "md-workbench.status";
+  o = (struct benchmark_options){
+  .interface = "POSIX",
+  .prefix = "./out",
+  .num = 1000,
+  .random_buffer_offset = -1,
+  .precreate = 3000,
+  .dset_count = 10,
+  .offset = 1,
+  .iterations = 3,
+  .file_size = 3901,
+  .run_info_file = "md-workbench.status"};
 }
 
 static void mdw_wait(double runtime){
@@ -550,7 +552,7 @@ void run_precreate(phase_stat_t * s, int current_index){
   }
 
   char * buf = malloc(o.file_size);
-  generate_memory_pattern(buf, o.file_size, 0, o.rank);
+  generate_memory_pattern(buf, o.file_size, o.random_buffer_offset, o.rank);
   double op_timer; // timer for individual operations
   size_t pos = -1; // position inside the individual measurement array
   double op_time;
@@ -566,7 +568,7 @@ void run_precreate(phase_stat_t * s, int current_index){
       if (NULL == aiori_fh){
         FAIL("Unable to open file %s", obj_name);
       }
-      update_write_memory_pattern(f * o.dset_count + d, buf, o.file_size, 0, o.rank);
+      update_write_memory_pattern(f * o.dset_count + d, buf, o.file_size, o.random_buffer_offset, o.rank);
       if ( o.file_size == (int) o.backend->xfer(WRITE, aiori_fh, (IOR_size_t *) buf, o.file_size, 0, o.backend_options)) {
         s->obj_create.suc++;
       }else{
@@ -647,7 +649,7 @@ void run_benchmark(phase_stat_t * s, int * current_index_p){
       }
       if ( o.file_size == (int) o.backend->xfer(READ, aiori_fh, (IOR_size_t *) buf, o.file_size, 0, o.backend_options) ) {
         if(o.verify_read){
-            if(verify_memory_pattern(f * o.dset_count + d, buf, o.file_size, 0, readRank) == 0){
+            if(verify_memory_pattern(f * o.dset_count + d, buf, o.file_size, o.random_buffer_offset, readRank) == 0){
               s->obj_read.suc++;
             }else{
               s->obj_read.err++;
@@ -801,6 +803,7 @@ static option_help options [] = {
   {0, "latency-all", "Keep the latency files from all ranks.", OPTION_FLAG, 'd', & o.latency_keep_all},
   {'P', "precreate-per-set", "Number of object to precreate per data set.", OPTION_OPTIONAL_ARGUMENT, 'd', & o.precreate},
   {'D', "data-sets", "Number of data sets covered per process and iteration.", OPTION_OPTIONAL_ARGUMENT, 'd', & o.dset_count},
+  {'G', NULL,        "Offset for the data in the read/write buffer, if not set, a random value is used", OPTION_OPTIONAL_ARGUMENT, 'd', & o.random_buffer_offset},
   {'o', NULL, "Output directory", OPTION_OPTIONAL_ARGUMENT, 's', & o.prefix},
   {'q', "quiet", "Avoid irrelevant printing.", OPTION_FLAG, 'd', & o.quiet_output},
   //{'m', "lim-free-mem", "Allocate memory until this limit (in MiB) is reached.", OPTION_OPTIONAL_ARGUMENT, 'd', & o.limit_memory},
@@ -905,6 +908,10 @@ mdworkbench_results_t* md_workbench_run(int argc, char ** argv, MPI_Comm world_c
     if(o.rank == 0)
       ERR("Invalid options, if running only the benchmark phase using -2 with stonewall option then use stonewall wear-out");
     exit(1);
+  }
+  if( o.random_buffer_offset == -1 ){
+      o.random_buffer_offset = time(NULL);
+      MPI_Bcast(& o.random_buffer_offset, 1, MPI_INT, 0, o.com);
   }
 
   if(o.backend->xfer_hints){

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -71,6 +71,53 @@ enum OutputFormat_t outputFormat;
 
 /***************************** F U N C T I O N S ******************************/
 
+void update_write_memory_pattern(uint64_t item, char * buf, size_t bytes, int buff_offset, int rank){
+  if(bytes >= 8){ // set the item number as first element of the buffer to be as much unique as possible
+    ((uint64_t*) buf)[0] = item;
+  }else{
+    buf[0] = (char) item;
+  }
+}
+
+void generate_memory_pattern(char * buf, size_t bytes, int buff_offset, int rank){
+  uint64_t * buffi = (uint64_t*) buf;
+  // first half of 64 bits use the rank
+  const uint64_t ranki = (uint64_t)(rank + 1) << 32 + buff_offset;
+  const size_t size = bytes / 8;
+  // the first 8 bytes are set to item number
+  for(size_t i=1; i < size; i++){
+    buffi[i] = (i + 1) + ranki;
+  }
+  for(size_t i=(bytes/8)*8; i < bytes; i++){
+    buf[i] = (char) i;
+  }
+}
+
+int verify_memory_pattern(int item, char * buffer, size_t bytes, int buff_offset, int pretendRank){
+  int error = 0;
+  // always read all data to ensure that performance numbers stay the same
+  if((bytes >= 8 && ((uint64_t*) buffer)[0] != item) || (bytes < 8 && buffer[0] != (char) item)){
+    error = 1;
+  }
+
+  uint64_t * buffi = (uint64_t*) buffer;
+  // first half of 64 bits use the rank, here need to apply rank shifting
+  uint64_t rank_mod = (uint64_t)(pretendRank + 1) << 32 + buff_offset;
+  // the first 8 bytes are set to item number
+  for(size_t i=1; i < bytes/8; i++){
+    uint64_t exp = (i + 1) + rank_mod;
+    if(buffi[i] != exp){
+      error = 1;
+    }
+  }
+  for(size_t i=(bytes/8)*8; i < bytes; i++){
+    if(buffer[i] != (char) i){
+      error = 1;
+    }
+  }
+  return error;
+}
+
 void* safeMalloc(uint64_t size){
   void * d = malloc(size);
   if (d == NULL){

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -35,6 +35,11 @@ extern enum OutputFormat_t outputFormat;  /* format of the output */
 void* safeMalloc(uint64_t size);
 void set_o_direct_flag(int *fd);
 
+void update_write_memory_pattern(uint64_t item, char * buf, size_t bytes, int buff_offset, int rank);
+void generate_memory_pattern(char * buf, size_t bytes, int buff_offset, int rank);
+/* check a data buffer, @return 0 if all is correct, otherwise 1 */
+int verify_memory_pattern(int item, char * buffer, size_t bytes, int buff_offset, int pretendRank);
+
 char *CurrentTimeString(void);
 int Regex(char *, char *);
 void ShowFileSystemSize(char * filename, const struct ior_aiori * backend, void * backend_options);


### PR DESCRIPTION
Add rank into I/O buffer to make individual files unique.

1) Before the reduce was missing, thus if any other rank than 0 encounters errors, then these were not counted.
2) Include the rank number into each value to make each file pattern unique.
3) Accelerate comparison using 64-bit type
4) Allow adding user-specified number (allowing to distinguish multiple runs) defeating dedup of previous runs.