### PR TITLE
MDTest allow storing information per rank for later analysis 

### DIFF
--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1395,7 +1395,11 @@ static void StoreRankInformation(int iterations){
         char * cpos = buff;
         cpos += sprintf(cpos, "%d", i);
         for(int e = 0; (e < MDTEST_TREE_CREATE_NUM) || (i == 0 && e < MDTEST_LAST_NUM); e++){
-          cpos += sprintf(cpos, ",%.10e,%.10e,%llu,%llu,%.10e", cur->rate[e], cur->time[e], (long long unsigned) cur->items[e], (long long unsigned)  cur->stonewall_last_item[e], cur->stonewall_time[e]);
+          if(cur->items[e] == 0){
+            cpos += sprintf(cpos, ",,,,,");
+          }else{
+            cpos += sprintf(cpos, ",%.10e,%.10e,%llu,%llu,%.10e", cur->items[e] / cur->time_before_barrier[e], cur->time_before_barrier[e], (long long unsigned) cur->items[e], (long long unsigned)  cur->stonewall_last_item[e], cur->stonewall_time[e]);
+          }
         }
         cpos += sprintf(cpos, "\n");
         int ret = fwrite(buff, cpos - buff, 1, fd);

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1393,12 +1393,12 @@ static void StoreRankInformation(int iterations){
         mdtest_results_t * cur = & results[i * iterations + iter];
         char buff[4096];
         char * cpos = buff;
-        cpos += sprintf(cpos, "%d", i);
+        cpos += sprintf(cpos, "%d,%llu", i, (long long unsigned) o.items);
         for(int e = 0; (e < MDTEST_TREE_CREATE_NUM) || (i == 0 && e < MDTEST_LAST_NUM); e++){
           if(cur->items[e] == 0){
-            cpos += sprintf(cpos, ",,,,,");
+            cpos += sprintf(cpos, ",,");
           }else{
-            cpos += sprintf(cpos, ",%.10e,%.10e,%llu,%llu,%.10e", cur->items[e] / cur->time_before_barrier[e], cur->time_before_barrier[e], (long long unsigned) cur->items[e], (long long unsigned)  cur->stonewall_last_item[e], cur->stonewall_time[e]);
+            cpos += sprintf(cpos, ",%.10e,%.10e", cur->items[e] / cur->time_before_barrier[e], cur->time_before_barrier[e]);
           }
         }
         cpos += sprintf(cpos, "\n");
@@ -1722,12 +1722,13 @@ void md_validate_tests() {
       if (fd == NULL){
         FAIL("Cannot open saveRankPerformanceDetails file for write!");
       }
-      int ret = fwrite("rank", 4, 1, fd);
+      char * head = "rank,items";
+      int ret = fwrite(head, strlen(head), 1, fd);
       for(int e = 0; e < MDTEST_LAST_NUM; e++){
         char buf[1024];
         const char * str = mdtest_test_name(e);
 
-        sprintf(buf, ",rate-%s,time-%s,items-%s,stonewall-items-%s,stonewall-time%s", str, str, str, str, str);
+        sprintf(buf, ",rate-%s,time-%s", str, str);
         ret = fwrite(buf, strlen(buf), 1, fd);
         if(ret != 1){
           FAIL("Cannot write header to saveRankPerformanceDetails file");

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -898,9 +898,20 @@ void rename_dir_test(const int dirs, const long dir_iter, const char *path, rank
     }
 }
 
+static void updateResult(mdtest_results_t * res, mdtest_test_num_t test, uint64_t item_count, int t, double * times, double * tBefore){
+  res->rate[test] = item_count/(times[t] - times[t-1]);
+  res->time[test] = times[t] - times[t-1];
+  if(tBefore){
+    res->time_before_barrier[test] = tBefore[t] - times[t-1];
+  }
+  res->items[test] = item_count;
+  res->stonewall_last_item[test] = o.items;
+}
+
 void directory_test(const int iteration, const int ntasks, const char *path, rank_progress_t * progress) {
     int size;
     double t[6] = {0};
+    double tBefore[6] = {0};
     char temp_path[MAX_PATHLEN];
     mdtest_results_t * res = & o.summary_table[iteration];
 
@@ -908,6 +919,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
 
     VERBOSE(1,-1,"Entering directory_test on %s", path );
 
+    tBefore[0] = GetTimeStamp();
     MPI_Barrier(testComm);
     t[0] = GetTimeStamp();
 
@@ -942,6 +954,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
       progress->stone_wall_timer_seconds = 0;
     }
 
+    tBefore[1] = GetTimeStamp();
     phase_end();
     t[1] = GetTimeStamp();
 
@@ -968,6 +981,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
         }
       }
     }
+    tBefore[2] = GetTimeStamp();
     phase_end();
     t[2] = GetTimeStamp();
 
@@ -994,6 +1008,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
         }
       }
     }
+    tBefore[3] = GetTimeStamp();
     phase_end();
 
     t[3] = GetTimeStamp();
@@ -1014,6 +1029,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
         rename_dir_test(1, dir_iter, temp_path, progress);
       }
     }
+    tBefore[4] = GetTimeStamp();
     phase_end();
 
     t[4] = GetTimeStamp();
@@ -1049,6 +1065,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
       }
     }
 
+    tBefore[5] = GetTimeStamp();
     phase_end();
     t[5] = GetTimeStamp();
 
@@ -1068,28 +1085,16 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
 
     /* calculate times */
     if (o.create_only) {
-        res->rate[MDTEST_DIR_CREATE_NUM] = o.items*size/(t[1] - t[0]);
-        res->time[MDTEST_DIR_CREATE_NUM] = t[1] - t[0];
-        res->items[MDTEST_DIR_CREATE_NUM] = o.items*size;
-        res->stonewall_last_item[MDTEST_DIR_CREATE_NUM] = o.items;
+      updateResult(res, MDTEST_DIR_CREATE_NUM, o.items*size, 1, t, tBefore);
     }
     if (o.stat_only) {
-        res->rate[MDTEST_DIR_STAT_NUM] = o.items*size/(t[2] - t[1]);
-        res->time[MDTEST_DIR_STAT_NUM] = t[2] - t[1];
-        res->items[MDTEST_DIR_STAT_NUM] = o.items*size;
-        res->stonewall_last_item[MDTEST_DIR_STAT_NUM] = o.items;
+      updateResult(res, MDTEST_DIR_STAT_NUM, o.items*size, 2, t, tBefore);
     }
     if (o.read_only) {
-        res->rate[MDTEST_DIR_READ_NUM] = o.items*size/(t[3] - t[2]);
-        res->time[MDTEST_DIR_READ_NUM] = t[3] - t[2];
-        res->items[MDTEST_DIR_READ_NUM] = o.items*size;
-        res->stonewall_last_item[MDTEST_DIR_READ_NUM] = o.items;
+      updateResult(res, MDTEST_DIR_READ_NUM, o.items*size, 3, t, tBefore);
     }
     if (o.remove_only) {
-        res->rate[MDTEST_DIR_REMOVE_NUM] = o.items*size/(t[5] - t[4]);
-        res->time[MDTEST_DIR_REMOVE_NUM] = t[5] - t[4];
-        res->items[MDTEST_DIR_REMOVE_NUM] = o.items*size;
-        res->stonewall_last_item[MDTEST_DIR_REMOVE_NUM] = o.items;
+      updateResult(res, MDTEST_DIR_REMOVE_NUM, o.items*size, 5, t, tBefore);
     }
     VERBOSE(1,-1,"   Directory creation: %14.3f sec, %14.3f ops/sec", t[1] - t[0], o.summary_table[iteration].rate[0]);
     VERBOSE(1,-1,"   Directory stat    : %14.3f sec, %14.3f ops/sec", t[2] - t[1], o.summary_table[iteration].rate[1]);
@@ -1178,11 +1183,13 @@ void file_test_create(const int iteration, const int ntasks, const char *path, r
 void file_test(const int iteration, const int ntasks, const char *path, rank_progress_t * progress) {
     int size;
     double t[5] = {0};
+    double tBefore[5] = {0};
     char temp_path[MAX_PATHLEN];
     MPI_Comm_size(testComm, &size);
 
     VERBOSE(3,5,"Entering file_test on %s", path);
 
+    tBefore[0] = GetTimeStamp();
     MPI_Barrier(testComm);
     t[0] = GetTimeStamp();
 
@@ -1216,6 +1223,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
       }
     }
 
+    tBefore[1] = GetTimeStamp();
     phase_end();
     t[1] = GetTimeStamp();
 
@@ -1239,6 +1247,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
       }
     }
 
+    tBefore[2] = GetTimeStamp();
     phase_end();
     t[2] = GetTimeStamp();
 
@@ -1266,6 +1275,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
       }
     }
 
+    tBefore[3] = GetTimeStamp();
     phase_end();
     t[3] = GetTimeStamp();
 
@@ -1296,6 +1306,7 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
       }
     }
 
+    tBefore[4] = GetTimeStamp();
     phase_end();
     t[4] = GetTimeStamp();
     if (o.remove_only) {
@@ -1319,28 +1330,16 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
     mdtest_results_t * res = & o.summary_table[iteration];
     /* calculate times */
     if (o.create_only) {
-        res->rate[MDTEST_FILE_CREATE_NUM] = o.items*size/(t[1] - t[0]);
-        res->time[MDTEST_FILE_CREATE_NUM] = t[1] - t[0];
-        res->items[MDTEST_FILE_CREATE_NUM] = o.items*o.size;
-        res->stonewall_last_item[MDTEST_FILE_CREATE_NUM] = o.items;
+      updateResult(res, MDTEST_FILE_CREATE_NUM, o.items*size, 1, t, tBefore);
     }
     if (o.stat_only) {
-        res->rate[MDTEST_FILE_STAT_NUM] = o.items*size/(t[2] - t[1]);
-        res->time[MDTEST_FILE_STAT_NUM] = t[2] - t[1];
-        res->items[MDTEST_FILE_STAT_NUM] = o.items*o.size;
-        res->stonewall_last_item[MDTEST_FILE_STAT_NUM] = o.items;
+      updateResult(res, MDTEST_FILE_STAT_NUM, o.items*size, 2, t, tBefore);
     }
     if (o.read_only) {
-        res->rate[MDTEST_FILE_READ_NUM] = o.items*o.size/(t[3] - t[2]);
-        res->time[MDTEST_FILE_READ_NUM] = t[3] - t[2];
-        res->items[MDTEST_FILE_READ_NUM] = o.items*o.size;
-        res->stonewall_last_item[MDTEST_FILE_READ_NUM] = o.items;
+      updateResult(res, MDTEST_FILE_READ_NUM, o.items*size, 3, t, tBefore);
     }
     if (o.remove_only) {
-        res->rate[MDTEST_FILE_REMOVE_NUM] = o.items*o.size/(t[4] - t[3]);
-        res->time[MDTEST_FILE_REMOVE_NUM] = t[4] - t[3];
-        res->items[MDTEST_FILE_REMOVE_NUM] = o.items*o.size;
-        res->stonewall_last_item[MDTEST_FILE_REMOVE_NUM] = o.items;
+      updateResult(res, MDTEST_FILE_REMOVE_NUM, o.items*size, 4, t, tBefore);
     }
 
     VERBOSE(1,-1,"  File creation     : %14.3f sec, %14.3f ops/sec", t[1] - t[0], o.summary_table[iteration].rate[4]);

--- a/src/mdtest.h
+++ b/src/mdtest.h
@@ -24,6 +24,7 @@ typedef struct
 {
     double rate[MDTEST_LAST_NUM]; /* Calculated throughput */
     double time[MDTEST_LAST_NUM]; /* Time */
+    double time_before_barrier[MDTEST_TREE_CREATE_NUM]; /* individual time before executing the barrier */
     uint64_t items[MDTEST_LAST_NUM]; /* Number of operations done */
 
     /* Statistics when hitting the stonewall */


### PR DESCRIPTION
when using the --saveRankPerformanceDetails=<FILE> option.

The CSV isn't perfectly formatted, yet, contains a bit much information.
