### PR TITLE
Improve and fix the reporting in MDTest. 

### DIFF
--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -899,11 +899,14 @@ void rename_dir_test(const int dirs, const long dir_iter, const char *path, rank
 }
 
 static void updateResult(mdtest_results_t * res, mdtest_test_num_t test, uint64_t item_count, int t, double * times, double * tBefore){
-  res->rate[test] = item_count/(times[t] - times[t-1]);
   res->time[test] = times[t] - times[t-1];
   if(tBefore){
     res->time_before_barrier[test] = tBefore[t] - times[t-1];
+  }else{
+    res->time_before_barrier[test] = res->time[test];
   }
+  res->rate[test] = item_count/res->time[test];
+  res->rate_before_barrier[test] = item_count/res->time_before_barrier[test];
   res->items[test] = item_count;
   res->stonewall_last_item[test] = o.items;
 }
@@ -984,7 +987,9 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
     tBefore[2] = GetTimeStamp();
     phase_end();
     t[2] = GetTimeStamp();
-
+    if (o.rename_dirs && o.items > 1) { // moved close to execution
+      updateResult(res, MDTEST_DIR_RENAME_NUM, o.items, 4, t, tBefore);
+    }
     /* read phase */
     if (o.read_only) {
       for (int dir_iter = 0; dir_iter < o.directory_loops; dir_iter ++){
@@ -1034,10 +1039,7 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
 
     t[4] = GetTimeStamp();
     if (o.rename_dirs && o.items > 1) { // moved close to execution
-        res->rate[MDTEST_DIR_RENAME_NUM] = o.items*size/(t[4] - t[3]);
-        res->time[MDTEST_DIR_RENAME_NUM] = t[4] - t[3];
-        res->items[MDTEST_DIR_RENAME_NUM] = o.items*size;
-        res->stonewall_last_item[MDTEST_DIR_RENAME_NUM] = o.items*size;
+      updateResult(res, MDTEST_DIR_RENAME_NUM, o.items, 4, t, tBefore);
     }
 
     if (o.remove_only) {
@@ -1085,16 +1087,16 @@ void directory_test(const int iteration, const int ntasks, const char *path, ran
 
     /* calculate times */
     if (o.create_only) {
-      updateResult(res, MDTEST_DIR_CREATE_NUM, o.items*size, 1, t, tBefore);
+      updateResult(res, MDTEST_DIR_CREATE_NUM, o.items, 1, t, tBefore);
     }
     if (o.stat_only) {
-      updateResult(res, MDTEST_DIR_STAT_NUM, o.items*size, 2, t, tBefore);
+      updateResult(res, MDTEST_DIR_STAT_NUM, o.items, 2, t, tBefore);
     }
     if (o.read_only) {
-      updateResult(res, MDTEST_DIR_READ_NUM, o.items*size, 3, t, tBefore);
+      updateResult(res, MDTEST_DIR_READ_NUM, o.items, 3, t, tBefore);
     }
     if (o.remove_only) {
-      updateResult(res, MDTEST_DIR_REMOVE_NUM, o.items*size, 5, t, tBefore);
+      updateResult(res, MDTEST_DIR_REMOVE_NUM, o.items, 5, t, tBefore);
     }
     VERBOSE(1,-1,"   Directory creation: %14.3f sec, %14.3f ops/sec", t[1] - t[0], o.summary_table[iteration].rate[0]);
     VERBOSE(1,-1,"   Directory stat    : %14.3f sec, %14.3f ops/sec", t[2] - t[1], o.summary_table[iteration].rate[1]);
@@ -1110,6 +1112,7 @@ int updateStoneWallIterations(int iteration, uint64_t items_done, double tstart,
   VERBOSE(1,1,"stonewall hit with %lld items", (long long) items_done );
   MPI_Allreduce(& items_done, & max_iter, 1, MPI_LONG_LONG_INT, MPI_MAX, testComm);
   o.summary_table[iteration].stonewall_time[MDTEST_FILE_CREATE_NUM] = GetTimeStamp() - tstart;
+  o.summary_table[iteration].stonewall_last_item[MDTEST_FILE_CREATE_NUM] = items_done;
   *out_max_iter = max_iter;
 
   // continue to the maximum...
@@ -1330,16 +1333,16 @@ void file_test(const int iteration, const int ntasks, const char *path, rank_pro
     mdtest_results_t * res = & o.summary_table[iteration];
     /* calculate times */
     if (o.create_only) {
-      updateResult(res, MDTEST_FILE_CREATE_NUM, o.items*size, 1, t, tBefore);
+      updateResult(res, MDTEST_FILE_CREATE_NUM, o.items, 1, t, tBefore);
     }
     if (o.stat_only) {
-      updateResult(res, MDTEST_FILE_STAT_NUM, o.items*size, 2, t, tBefore);
+      updateResult(res, MDTEST_FILE_STAT_NUM, o.items, 2, t, tBefore);
     }
     if (o.read_only) {
-      updateResult(res, MDTEST_FILE_READ_NUM, o.items*size, 3, t, tBefore);
+      updateResult(res, MDTEST_FILE_READ_NUM, o.items, 3, t, tBefore);
     }
     if (o.remove_only) {
-      updateResult(res, MDTEST_FILE_REMOVE_NUM, o.items*size, 4, t, tBefore);
+      updateResult(res, MDTEST_FILE_REMOVE_NUM, o.items, 4, t, tBefore);
     }
 
     VERBOSE(1,-1,"  File creation     : %14.3f sec, %14.3f ops/sec", t[1] - t[0], o.summary_table[iteration].rate[4]);
@@ -1369,11 +1372,6 @@ char const * mdtest_test_name(int i){
   return NULL;
 }
 
-int calc_allreduce_index(int iter, int rank, int op){
-  int tableSize = MDTEST_LAST_NUM;
-  return iter * tableSize * o.size + rank * tableSize + op;
-}
-
 /*
  * Store the results of each process in a file
  */
@@ -1385,7 +1383,7 @@ static void StoreRankInformation(int iterations){
       FAIL("Cannot open saveRankPerformanceDetails file for writes!");
     }
 
-    mdtest_results_t * results = malloc(size * o.size);
+    mdtest_results_t * results = safeMalloc(size * o.size);
     MPI_Gather(o.summary_table, size / sizeof(double), MPI_DOUBLE, results, size / sizeof(double), MPI_DOUBLE, 0, testComm);
 
     for(int iter = 0; iter < iterations; iter++){
@@ -1410,213 +1408,273 @@ static void StoreRankInformation(int iterations){
       }
     }
     fclose(fd);
+    free(results);
   }else{
     /* this is a hack for now assuming all datatypes in the structure are double */
     MPI_Gather(o.summary_table, size / sizeof(double), MPI_DOUBLE, NULL, size / sizeof(double), MPI_DOUBLE, 0, testComm);
   }
 }
 
-void summarize_results(int iterations, int print_time) {
-    char const * access;
-    int i, j, k;
-    int start, stop, tableSize = MDTEST_LAST_NUM;
-    double min, max, mean, sd, sum, var, curr = 0;
-    double imin, imax, isum, icur; // calculation per iteration
+static mdtest_results_t* get_result_index(mdtest_results_t* all_results, int proc, int iter, int interation_count){
+  return & all_results[proc * interation_count + iter];
+}
 
-    double all[iterations * o.size * tableSize];
+static void summarize_results_rank0(int iterations,  mdtest_results_t * all_results, int print_time) {
+  int start, stop;
+  double min, max, mean, sd, sum, var, curr = 0;
+  double imin, imax, imean, isum, icur; // calculation per iteration
+  char const * access;
+  /* if files only access, skip entries 0-3 (the dir tests) */
+  if (o.files_only && ! o.dirs_only) {
+      start = MDTEST_FILE_CREATE_NUM;
+  } else {
+      start = 0;
+  }
 
+  /* if directories only access, skip entries 4-7 (the file tests) */
+  if (o.dirs_only && !o.files_only) {
+      stop = MDTEST_FILE_CREATE_NUM;
+  } else {
+      stop = MDTEST_TREE_CREATE_NUM;
+  }
 
-    VERBOSE(1,-1,"Entering summarize_results..." );
+  /* special case: if no directory or file tests, skip all */
+  if (!o.dirs_only && !o.files_only) {
+      start = stop = 0;
+  }
 
-    MPI_Barrier(testComm);
-    for(int i=0; i < iterations; i++){
-      if(print_time){
-        MPI_Gather(& o.summary_table[i].time[0], tableSize, MPI_DOUBLE, & all[i*tableSize * o.size], tableSize, MPI_DOUBLE, 0, testComm);
-      }else{
-        MPI_Gather(& o.summary_table[i].rate[0], tableSize, MPI_DOUBLE, & all[i*tableSize * o.size], tableSize, MPI_DOUBLE, 0, testComm);
-      }
-    }
-
-    if(o.print_all_proc && 0){
-      // This code prints the result table for debugging
-      for (i = 0; i < tableSize; i++) {
-        for (j = 0; j < iterations; j++) {
-          access = mdtest_test_name(i);
-          if(access == NULL){
-            continue;
-          }
-          curr = o.summary_table[j].rate[i];
-          fprintf(out_logfile, "Rank %d Iter %d Test %-20s Rate: %e\n", rank, j, access, curr);
-        }
-      }
-    }
-
-    if (rank != 0) {
-      return;
-    }
-
-    /* if files only access, skip entries 0-3 (the dir tests) */
-    if (o.files_only && ! o.dirs_only) {
-        start = MDTEST_FILE_CREATE_NUM;
-    } else {
-        start = 0;
-    }
-
-    /* if directories only access, skip entries 4-7 (the file tests) */
-    if (o.dirs_only && !o.files_only) {
-        stop = MDTEST_FILE_CREATE_NUM;
-    } else {
-        stop = MDTEST_TREE_CREATE_NUM;
-    }
-
-    /* special case: if no directory or file tests, skip all */
-    if (!o.dirs_only && !o.files_only) {
-        start = stop = 0;
-    }
-
-    if(o.print_all_proc){
-      fprintf(out_logfile, "\nPer process result (%s):\n", print_time ? "time" : "rate");
-      for (j = 0; j < iterations; j++) {
-        fprintf(out_logfile, "iteration: %d\n", j);
-        for (i = start; i < tableSize; i++) {
-          access = mdtest_test_name(i);
-          if(access == NULL){
-            continue;
-          }
-          fprintf(out_logfile, "Test %s", access);
-          for (k=0; k < o.size; k++) {
-            curr = all[calc_allreduce_index(j, k, i)];
-            fprintf(out_logfile, "%c%e", (k==0 ? ' ': ','), curr);
-          }
-          fprintf(out_logfile, "\n");
-        }
-      }
-    }
-
-    VERBOSE(0,-1,"\nSUMMARY %s: (of %d iterations)", print_time ? "time": "rate", iterations);
-    VERBOSE(0,-1,"   Operation         per Rank: Max            Min           Mean          Std Dev     per Iteration: Max            Min           Mean");
-    VERBOSE(0,-1,"   ---------                   ---            ---           ----          -------                    ---            ---           ----");
-
-    for (i = start; i < stop; i++) {
-            min = max = all[i];
-            sum = var = 0;
-            imin = 1e308;
-            isum = imax = 0;
-            for (j = 0; j < iterations; j++) {
-                icur = print_time ? 0 : 1e308;
-                for (k=0; k < o.size; k++) {
-                    curr = all[calc_allreduce_index(j, k, i)];
-                    if (min > curr) {
-                        min = curr;
-                    }
-                    if (max < curr) {
-                        max = curr;
-                    }
-                    if(print_time){
-                      if(icur < curr){
-                        icur = curr;
-                      }
-                    }else{
-                      if(icur > curr){
-                        icur = curr;
-                      }
-                    }
-                    sum += curr;
-                }
-                if(icur > imax){
-                  imax = icur;
-                }
-                if(icur < imin){
-                  imin = icur;
-                }
-                isum += icur;
-            }
-            mean = sum / (iterations * o.size);
-            for (k=0; k < o.size; k++) {
-                for (j = 0; j < iterations; j++) {
-                    var += pow((mean -  all[(k*tableSize*iterations)
-                                            + (j*tableSize) + i]), 2);
-                }
-            }
-            var = var / (iterations * o.size);
-            sd = sqrt(var);
-            access = mdtest_test_name(i);
-            if (i != 2) {
-                fprintf(out_logfile, "   %-22s ", access);
-                fprintf(out_logfile, "%14.3f ", max);
-                fprintf(out_logfile, "%14.3f ", min);
-                fprintf(out_logfile, "%14.3f ", mean);
-                fprintf(out_logfile, "%14.3f ", sd);
-                fprintf(out_logfile, "%18.3f ", imax);
-                fprintf(out_logfile, "%14.3f ", imin);
-                fprintf(out_logfile, "%14.3f\n", isum / iterations);
-                fflush(out_logfile);
-            }
-    }
-
-    // TODO generalize once more stonewall timers are supported
-    double stonewall_time = 0;
-    uint64_t stonewall_items = 0;
-    for(int i=0; i < iterations; i++){
-      if(o.summary_table[i].stonewall_time[MDTEST_FILE_CREATE_NUM]){
-        stonewall_time += o.summary_table[i].stonewall_time[MDTEST_FILE_CREATE_NUM];
-        stonewall_items += o.summary_table[i].stonewall_item_sum[MDTEST_FILE_CREATE_NUM];
-      }
-    }
-    if(stonewall_items != 0){
-      fprintf(out_logfile, "   File create (stonewall) ");
-      fprintf(out_logfile, "%13s %14s %14.3f %14s\n", "NA", "NA", print_time ? stonewall_time :  stonewall_items / stonewall_time, "NA");
-    }
-
-    /* calculate tree create/remove rates, applies only to Rank 0 */
-    for (i = MDTEST_TREE_CREATE_NUM; i < tableSize; i++) {
-        min = max = all[i];
-        sum = var = 0;
-        imin = imax = all[i];
-        isum = 0;
-        for (j = 0; j < iterations; j++) {
-            if(print_time){
-              curr = o.summary_table[j].time[i];
-            }else{
-              curr = o.summary_table[j].rate[i];
-            }
-            if (min > curr) {
-              min = curr;
-            }
-            if (max < curr) {
-              max =  curr;
-            }
-            sum += curr;
-            if(curr > imax){
-              imax = curr;
-            }
-            if(curr < imin){
-              imin = curr;
-            }
-        }
-        mean = sum / (iterations);
-        for (j = 0; j < iterations; j++) {
-            if(print_time){
-              curr = o.summary_table[j].time[i];
-            }else{
-              curr = o.summary_table[j].rate[i];
-            }
-
-            var += pow((mean -  curr), 2);
-        }
-        var = var / (iterations);
-        sd = sqrt(var);
+  if(o.print_all_proc){
+    fprintf(out_logfile, "\nPer process result (%s):\n", print_time ? "time" : "rate");
+    for (int j = 0; j < iterations; j++) {
+      fprintf(out_logfile, "iteration: %d\n", j);
+      for (int i = start; i < MDTEST_LAST_NUM; i++) {
         access = mdtest_test_name(i);
-        fprintf(out_logfile, "   %-22s ", access);
-        fprintf(out_logfile, "%14.3f ", max);
-        fprintf(out_logfile, "%14.3f ", min);
-        fprintf(out_logfile, "%14.3f ", mean);
-        fprintf(out_logfile, "%14.3f ", sd);
-        fprintf(out_logfile, "%18.3f ", imax);
-        fprintf(out_logfile, "%14.3f ", imin);
-        fprintf(out_logfile, "%14.3f\n", sum / iterations);
-        fflush(out_logfile);
+        if(access == NULL){
+          continue;
+        }
+        fprintf(out_logfile, "Test %s", access);
+        for (int k=0; k < o.size; k++) {
+          mdtest_results_t * cur = get_result_index(all_results, k, j, iterations);
+          if(print_time){
+            curr = cur->time_before_barrier[i];
+          }else{
+            curr = cur->rate_before_barrier[i];
+          }
+          fprintf(out_logfile, "%c%e", (k==0 ? ' ': ','), curr);
+        }
+        fprintf(out_logfile, "\n");
+      }
     }
+  }
+
+  VERBOSE(0, -1, "\nSUMMARY %s: (of %d iterations)", print_time ? "time" : "rate", iterations);
+  VERBOSE(0, -1,
+          "   Operation         per Rank: Max            Min           Mean    "
+          "   per Iteration: Max            Min           Mean         Std Dev");
+  VERBOSE(0, -1,
+          "   ---------                   ---            ---           ----    "
+          "                  ---            ---           ----         -------");
+  for (int i = start; i < stop; i++) {
+    min = 1e308;
+    max = 0;
+    sum = var = 0;
+    imin = 1e308;
+    isum = imax = 0;
+    double iter_result[iterations];
+    for (int j = 0; j < iterations; j++) {
+      icur = print_time ? 0 : 1e308;
+      for (int k = 0; k < o.size; k++) {
+        mdtest_results_t * cur = get_result_index(all_results, k, j, iterations);
+        if(print_time){
+          curr = cur->time_before_barrier[i];
+        }else{
+          curr = cur->rate_before_barrier[i];
+        }
+        if (min > curr) {
+          min = curr;
+        }
+        if (max < curr) {
+          max = curr;
+        }
+        sum += curr;
+
+        if (print_time) {
+          curr = cur->time[i];
+          if (icur < curr) {
+            icur = curr;
+          }
+        } else {
+          curr = cur->rate[i];
+          if (icur > curr) {
+            icur = curr;
+          }
+        }
+      }
+
+      if (icur > imax) {
+        imax = icur;
+      }
+      if (icur < imin) {
+        imin = icur;
+      }
+      isum += icur;
+      if(print_time){
+        iter_result[j] = icur;
+      }else{
+        iter_result[j] = icur * o.size;
+      }
+    }
+    mean = sum / iterations / o.size;
+    imean = isum / iterations;
+    if(! print_time){
+      imax *= o.size;
+      imin *= o.size;
+      isum *= o.size;
+      imean *= o.size;
+    }
+    for (int j = 0; j < iterations; j++) {
+      var += (imean - iter_result[j]) * (imean - iter_result[j]);
+    }
+    var = var / (iterations - 1);
+    sd = sqrt(var);
+    access = mdtest_test_name(i);
+    if (i != 2) {
+      fprintf(out_logfile, "   %-22s ", access);
+      fprintf(out_logfile, "%14.3f ", max);
+      fprintf(out_logfile, "%14.3f ", min);
+      fprintf(out_logfile, "%14.3f ", mean);
+      fprintf(out_logfile, "%18.3f ", imax);
+      fprintf(out_logfile, "%14.3f ", imin);
+      fprintf(out_logfile, "%14.3f ", imean);
+      fprintf(out_logfile, "%14.3f\n", iterations == 1 ? 0 : sd);
+      fflush(out_logfile);
+    }
+  }
+
+  /* calculate tree create/remove rates, applies only to Rank 0 */
+  for (int i = MDTEST_TREE_CREATE_NUM; i < MDTEST_LAST_NUM; i++) {
+      min = imin = 1e308;
+      max = imax = 0;
+      sum = var = 0;
+      for (int j = 0; j < iterations; j++) {
+          if(print_time){
+            curr = o.summary_table[j].time[i];
+          }else{
+            curr = o.summary_table[j].rate[i];
+          }
+          if (min > curr) {
+            min = curr;
+          }
+          if (max < curr) {
+            max =  curr;
+          }
+          sum += curr;
+          if(curr > imax){
+            imax = curr;
+          }
+          if(curr < imin){
+            imin = curr;
+          }
+      }
+
+      mean = sum / (iterations);
+
+      for (int j = 0; j < iterations; j++) {
+          if(print_time){
+            curr = o.summary_table[j].time[i];
+          }else{
+            curr = o.summary_table[j].rate[i];
+          }
+          var += (mean -  curr)*(mean -  curr);
+      }
+      var = var / (iterations - 1);
+      sd = sqrt(var);
+      access = mdtest_test_name(i);
+      fprintf(out_logfile, "   %-22s ", access);
+      fprintf(out_logfile, "%14.3f ", max);
+      fprintf(out_logfile, "%14.3f ", min);
+      fprintf(out_logfile, "%14.3f ", mean);
+      fprintf(out_logfile, "%18.3f ", imax);
+      fprintf(out_logfile, "%14.3f ", imin);
+      fprintf(out_logfile, "%14.3f ", sum / iterations);
+      fprintf(out_logfile, "%14.3f\n", iterations == 1 ? 0 : sd);
+      fflush(out_logfile);
+  }
+}
+
+/*
+ Output the results and summarize them into rank 0's o.summary_table
+ */
+void summarize_results(int iterations, mdtest_results_t * results) {
+  const size_t size = sizeof(mdtest_results_t) * iterations;
+  mdtest_results_t * all_results = NULL;
+  if(rank == 0){
+    all_results = safeMalloc(size * o.size);
+    memset(all_results, 0, size * o.size);
+    MPI_Gather(o.summary_table, size / sizeof(double), MPI_DOUBLE, all_results, size / sizeof(double), MPI_DOUBLE, 0, testComm);
+    // calculate the aggregated values for all processes
+    for(int j=0; j < iterations; j++){
+      for(int i=0; i < MDTEST_LAST_NUM; i++){
+        //double sum_rate = 0;
+        double max_time = 0;
+        double max_stonewall_time = 0;
+        uint64_t sum_items = 0;
+
+        // reduce over the processes
+        for(int p=0; p < o.size; p++){
+          mdtest_results_t * cur = get_result_index(all_results, p, j, iterations);
+          //sum_rate += all_results[p + j*p]->rate[i];
+          double t = cur->time[i];
+          max_time = max_time < t ? t : max_time;
+
+          sum_items += cur->items[i];
+
+          t = cur->stonewall_time[i];
+          max_stonewall_time = max_stonewall_time < t ? t : max_stonewall_time;
+        }
+
+        results[j].items[i] = sum_items;
+        results[j].time[i] = max_time;
+        results[j].stonewall_time[i] = max_stonewall_time;
+        if(sum_items == 0){
+          results[j].rate[i] = 0.0;
+        }else{
+          results[j].rate[i] = sum_items / max_time;
+        }
+
+        /* These results have already been reduced to Rank 0 */
+        results[j].stonewall_item_sum[i] = o.summary_table[j].stonewall_item_sum[i];
+        results[j].stonewall_item_min[i] = o.summary_table[j].stonewall_item_min[i];
+        results[j].stonewall_time[i] = o.summary_table[j].stonewall_time[i];
+      }
+    }
+  }else{
+    MPI_Gather(o.summary_table, size / sizeof(double), MPI_DOUBLE, NULL, size / sizeof(double), MPI_DOUBLE, 0, testComm);
+  }
+
+  /* share global results across processes as these are returned by the API */
+  MPI_Bcast(results, size / sizeof(double), MPI_DOUBLE, 0, testComm);
+
+  /* update relevant result values with local values as these are returned by the API */
+  for(int j=0; j < iterations; j++){
+    for(int i=0; i < MDTEST_LAST_NUM; i++){
+      results[j].time_before_barrier[i] = o.summary_table[j].time_before_barrier[i];
+      results[j].stonewall_last_item[i] = o.summary_table[j].stonewall_last_item[i];
+    }
+  }
+
+  if(rank != 0){
+    return;
+  }
+
+  if (o.print_rate_and_time){
+    summarize_results_rank0(iterations, all_results, 0);
+    summarize_results_rank0(iterations, all_results, 1);
+  }else{
+    summarize_results_rank0(iterations, all_results, o.print_time);
+  }
+
+  free(all_results);
 }
 
 /* Checks to see if the test setup is valid.  If it isn't, fail. */
@@ -2413,18 +2471,14 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     /* setup summary table for recording results */
     o.summary_table = (mdtest_results_t *) safeMalloc(iterations * sizeof(mdtest_results_t));
     memset(o.summary_table, 0, iterations * sizeof(mdtest_results_t));
-    for(int i=0; i < iterations; i++){
-      for(int j=0; j < MDTEST_LAST_NUM; j++){
-        o.summary_table[i].rate[j] = 0.0;
-        o.summary_table[i].time[j] = 0.0;
-      }
-    }
 
     if (o.unique_dir_per_task) {
         sprintf(o.base_tree_name, "mdtest_tree.%d", rank);
     } else {
         sprintf(o.base_tree_name, "mdtest_tree");
     }
+
+    mdtest_results_t * aggregated_results = safeMalloc(iterations * sizeof(mdtest_results_t));
 
     /* default use shared directory */
     strcpy(o.mk_name, "mdtest.shared.");
@@ -2465,12 +2519,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
             // keep track of the current status for stonewalling
             mdtest_iteration(i, j, testgroup, & o.summary_table[j]);
         }
-        if (o.print_rate_and_time){
-          summarize_results(iterations, 0);
-          summarize_results(iterations, 1);
-        }else{
-          summarize_results(iterations, o.print_time);
-        }
+        summarize_results(iterations, aggregated_results);
         if(o.saveRankDetailsCSV){
           StoreRankInformation(iterations);
         }
@@ -2501,6 +2550,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     if (o.write_bytes > 0) {
       free(o.write_buffer);
     }
+    free(o.summary_table);
 
-    return o.summary_table;
+    return aggregated_results;
 }

--- a/src/mdtest.h
+++ b/src/mdtest.h
@@ -22,16 +22,17 @@ typedef enum {
 
 typedef struct
 {
-    double rate[MDTEST_LAST_NUM]; /* Calculated throughput */
+    double rate[MDTEST_LAST_NUM]; /* Calculated throughput after the barrier */
+    double rate_before_barrier[MDTEST_LAST_NUM]; /* Calculated throughput before the barrier */
     double time[MDTEST_LAST_NUM]; /* Time */
     double time_before_barrier[MDTEST_TREE_CREATE_NUM]; /* individual time before executing the barrier */
-    uint64_t items[MDTEST_LAST_NUM]; /* Number of operations done */
+    uint64_t items[MDTEST_LAST_NUM]; /* Number of operations done in this process*/
 
     /* Statistics when hitting the stonewall */
-    double   stonewall_time[MDTEST_LAST_NUM];     /* runtime until completion / hit of the stonewall */
-    uint64_t stonewall_last_item[MDTEST_LAST_NUM]; /* Max number of items a process has accessed */
-    uint64_t stonewall_item_min[MDTEST_LAST_NUM];  /* Min number of items a process has accessed */
-    uint64_t stonewall_item_sum[MDTEST_LAST_NUM];  /* Total number of items accessed until stonewall */
+    double   stonewall_time[MDTEST_LAST_NUM];     /* Max runtime of any process until completion / hit of the stonewall */
+    uint64_t stonewall_last_item[MDTEST_LAST_NUM]; /* The number of items a process has accessed */
+    uint64_t stonewall_item_min[MDTEST_LAST_NUM];  /* Min number of items any process has accessed */
+    uint64_t stonewall_item_sum[MDTEST_LAST_NUM];  /* Total number of items accessed by all processes until stonewall */
 } mdtest_results_t;
 
 mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * out_logfile);


### PR DESCRIPTION
Reporting per rank now outputs the performance of the individual rank (before the barrier), the iteration throughput includes the barrier time (if not -B=0 is set). 
Before, it was the time after the barrier.
Bugfix also the calculation of the standard deviation which now applies to iteration.

Example:
The following will use the DUMMY plugin which needs 1000us per create/access but only on Rank 0 of two Ranks for two iterations:
$ mpiexec -np 2 --oversubscribe  ./src/mdtest -n 1000 -i 2 -a DUMMY   --saveRankPerformanceDetails=test.csv   --dummy.delay-only-rank0 --dummy.delay-create=1000  -w 1024 -e 1024 --dummy.delay-xfer=1000 -B=0 -P 

```
SUMMARY rate: (of 2 iterations)
   Operation         per Rank: Max            Min           Mean       per Iteration: Max            Min           Mean         Std Dev
   ---------                   ---            ---           ----                      ---            ---           ----         -------
   Directory creation        8405418.838    1785570.030    5115828.881       16677153.082    3571140.060   10124146.571    9267350.682
   Directory stat            3622024.180     894498.614    2206792.683        6710886.400    1788997.228    4249941.814    3480301.210
   Directory rename          5461333.333    1383345.646    3415483.369       10810061.856    2766691.293    6788376.574    5687521.869
   Directory removal         8542370.672    2150925.128    5335244.581       16946682.828    4301850.256   10624266.542    8941246.859
   File creation             6898526.316        459.439    2161950.242            920.130        918.879        919.505          0.885
   File stat                 3637731.136    3412777.868    3518108.288        6898526.316    6825555.736    6862041.026      51597.992
   File read                 3472105.960        915.615    1589156.478           1842.347       1831.230       1836.789          7.860
   File removal              8338576.541    6096372.093    7396166.889       16008793.893   12192744.186   14100769.040    2698354.625
   Tree creation              838860.800      32263.877     435562.338         838860.800      32263.877     435562.338     570350.154
   Tree removal              1048576.000     524288.000     786432.000        1048576.000     524288.000     786432.000     370727.600

SUMMARY time: (of 2 iterations)
   Operation         per Rank: Max            Min           Mean       per Iteration: Max            Min           Mean         Std Dev
   ---------                   ---            ---           ----                      ---            ---           ----         -------
   Directory creation              0.001          0.000          0.000              0.001          0.000          0.001          0.001
   Directory stat                  0.001          0.000          0.001              0.002          0.001          0.001          0.001
   Directory rename                0.001          0.000          0.000              0.001          0.000          0.001          0.001
   Directory removal               0.000          0.000          0.000              0.001          0.000          0.001          0.000
   File creation                   2.177          0.000          1.088              4.353          4.347          4.350          0.004
   File stat                       0.000          0.000          0.000              0.001          0.001          0.001          0.000
   File read                       1.092          0.000          0.545              2.184          2.171          2.178          0.009
   File removal                    0.000          0.000          0.000              0.000          0.000          0.000          0.000
   Tree creation                   0.000          0.000          0.000              0.000          0.000          0.000          0.000
   Tree removal                    0.000          0.000          0.000              0.000          0.000          0.000          0.000

```

Look at creation and read times.
The new behavior matches my expectations now.
The behavior for the calculation per iteration is not changed, except that the SD calculation is now part of it.
This doesn't invalidate any previous results, just is more precise what a calculation per rank means.