### PR TITLE
Make noncontiguous I/O work again

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1026,7 +1026,9 @@ static void InitTests(IOR_test_t *tests)
 static void XferBuffersSetup(IOR_io_buffers* ioBuffers, IOR_param_t* test,
                              int pretendRank)
 {
-        ioBuffers->buffer = aligned_buffer_alloc(test->transferSize, test->gpuMemoryFlags);
+        /* MPI-IO driver when doing noncontiguous I/O will construct an access
+         * pattern that describes the entire strided access in a single go */
+        ioBuffers->buffer = aligned_buffer_alloc(test->transferSize*test->segmentCount, test->gpuMemoryFlags);
 }
 
 /*


### PR DESCRIPTION
Fixes  #340 

MPI-IO's treatment of noncontiguous is probably a lot different from the other drivers --- I don't even know what noncontiguous S3 access would mean for example.

I don't know why it was disabled a year ago, but this removes the hard error upon requesting it and fixes a memory allocation problem when using it:

    $ mpiexec -np 4 ./src/ior --mpiio.useFileView --mpiio.showHints --mpiio.useStridedDatatype \
        -s 4 -b 1M -t 1M -c -a MPIIO -o testfile1

There is presently no way to know from the output if the benchmark ran noncontig or contig (one could infer if the "useFileView" information was part of the output summary)