### PR TITLE
reset test comm to world comm since it can be used in finalize callbacks.

### DIFF
--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -2546,6 +2546,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     }
 
     MPI_Group_free(&worldgroup);
+    testComm = world_com;
 
     if (created_root_dir && o.remove_only && o.backend->rmdir(o.testdirpath, o.backend_options) != 0) {
         FAIL("Unable to remove test directory path %s", o.testdirpath);


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>