### PR TITLE
WIP: randomized datapackettype

### DIFF
--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -187,7 +187,7 @@ static int HDF5_check_params(aiori_mod_opt_t * options){
     /* no-fill option not available until hdf5-1.6.x */
 #if (H5_VERS_MAJOR > 0 && H5_VERS_MINOR > 5)
 #else
-    ERRF("'no fill' option not available in HDF5");
+    ERR("'no fill' option not available in HDF5");
 #endif
 #else
     WARN("unable to determine HDF5 version for 'no fill' usage");

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -546,7 +546,7 @@ aiori_fd_t *POSIX_Open(char *testFileName, int flags, aiori_mod_opt_t * param)
         if (o->lustre_ignore_locks) {
                 int lustre_ioctl_flags = LL_FILE_IGNORE_LOCK;
                 if (verbose >= VERBOSE_1) {
-                        EINFO("** Disabling lustre range locking **\n");
+                        EINFO("** Disabling lustre range locking **\n", 0);
                 }
                 if (ioctl(pfd->fd, LL_IOC_SETFLAGS, &lustre_ioctl_flags) == -1)
                         ERRF("ioctl(%d, LL_IOC_SETFLAGS, ...) failed", pfd->fd);

--- a/src/iordef.h
+++ b/src/iordef.h
@@ -22,7 +22,8 @@
 typedef enum {
   DATA_TIMESTAMP, /* Will not include any offset, hence each buffer will be the same */
   DATA_OFFSET,
-  DATA_INCOMPRESSIBLE /* Will include the offset as well */
+  DATA_INCOMPRESSIBLE,  /* Will include the offset as well */
+  DATA_RANDOM           /* fully scrambled blocks */
 } ior_dataPacketType_e;
 
 #ifdef _WIN32

--- a/src/md-workbench.c
+++ b/src/md-workbench.c
@@ -826,7 +826,7 @@ static option_help options [] = {
   {'w', "stonewall-timer", "Stop each benchmark iteration after the specified seconds (if not used with -W this leads to process-specific progress!)", OPTION_OPTIONAL_ARGUMENT, 'd', & o.stonewall_timer},
   {'W', "stonewall-wear-out", "Stop with stonewall after specified time and use a soft wear-out phase -- all processes perform the same number of iterations", OPTION_FLAG, 'd', & o.stonewall_timer_wear_out},
   {'X', "verify-read", "Verify the data on read", OPTION_FLAG, 'd', & o.verify_read},
-  {0, "dataPacketType", "type of packet that will be created [offset|incompressible|timestamp|o|i|t]", OPTION_OPTIONAL_ARGUMENT, 's', & o.packetTypeStr},
+  {0, "dataPacketType", "type of packet that will be created [offset|incompressible|timestamp|random|o|i|t|r]", OPTION_OPTIONAL_ARGUMENT, 's', & o.packetTypeStr},
   {0, "allocateBufferOnGPU", "Allocate the buffer on the GPU.", OPTION_FLAG, 'd', & o.gpu_memory_flags},
   {0, "start-item", "The iteration number of the item to start with, allowing to offset the operations", OPTION_OPTIONAL_ARGUMENT, 'l', & o.start_item_number},
   {0, "print-detailed-stats", "Print detailed machine parsable statistics.", OPTION_FLAG, 'd', & o.print_detailed_stats},

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -2230,7 +2230,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
       {'Y', NULL,        "call the sync command after each phase (included in the timing; note it causes all IO to be flushed from your node)", OPTION_FLAG, 'd', & o.call_sync},
       {'z', NULL,        "depth of hierarchical directory structure", OPTION_OPTIONAL_ARGUMENT, 'd', & o.depth},
       {'Z', NULL,        "print time instead of rate", OPTION_FLAG, 'd', & o.print_time},
-      {0, "dataPacketType", "type of packet that will be created [offset|incompressible|timestamp|o|i|t]", OPTION_OPTIONAL_ARGUMENT, 's', & packetType},
+      {0, "dataPacketType", "type of packet that will be created [offset|incompressible|timestamp|random|o|i|t|r]", OPTION_OPTIONAL_ARGUMENT, 's', & packetType},
       {0, "allocateBufferOnGPU", "Allocate the buffer on the GPU.", OPTION_FLAG, 'd', & o.gpu_memory_flags},
       {0, "warningAsErrors",        "Any warning should lead to an error.", OPTION_FLAG, 'd', & aiori_warning_as_errors},
       {0, "saveRankPerformanceDetails", "Save the individual rank information into this CSV file.", OPTION_OPTIONAL_ARGUMENT, 's', & o.saveRankDetailsCSV},

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1955,7 +1955,7 @@ static void mdtest_iteration(int i, int j, MPI_Group testgroup, mdtest_results_t
 #ifdef HAVE_LUSTRE_LUSTREAPI
           /* internal node for branching, can be non-striped for children */
           if (o.global_dir_layout && o.unique_dir_per_task && llapi_dir_set_default_lmv_stripe(o.testdir, -1, 0, LMV_HASH_TYPE_FNV_1A_64, NULL) == -1) {
-              EWARNF("Unable to reset to global default directory layout");
+              EWARNF("Unable to reset to global default directory layout", 0);
           }
 #endif /* HAVE_LUSTRE_LUSTREAPI */
       }

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -450,7 +450,7 @@ option_help * createGlobalOptions(IOR_param_t * params){
     {'j', NULL,        "outlierThreshold -- warn on outlier N seconds from mean", OPTION_OPTIONAL_ARGUMENT, 'd', & params->outlierThreshold},
     {'k', NULL,        "keepFile -- don't remove the test file(s) on program exit", OPTION_FLAG, 'd', & params->keepFile},
     {'K', NULL,        "keepFileWithError  -- keep error-filled file(s) after data-checking", OPTION_FLAG, 'd', & params->keepFileWithError},
-    {'l', "dataPacketType",        "datapacket type-- type of packet that will be created [offset|incompressible|timestamp|o|i|t]", OPTION_OPTIONAL_ARGUMENT, 's', &  params->buffer_type},
+    {'l', "dataPacketType",        "datapacket type-- type of packet that will be created [offset|incompressible|timestamp|random|o|i|t|r]", OPTION_OPTIONAL_ARGUMENT, 's', &  params->buffer_type},
     {'m', NULL,        "multiFile -- use number of reps (-i) for multiple file count", OPTION_FLAG, 'd', & params->multiFile},
     {'M', NULL,        "memoryPerNode -- hog memory on the node  (e.g.: 2g, 75%)", OPTION_OPTIONAL_ARGUMENT, 's', & params->memoryPerNodeStr},
     {'N', NULL,        "numTasks -- number of tasks that are participating in the test (overrides MPI)", OPTION_OPTIONAL_ARGUMENT, 'd', & params->numTasks},

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -99,16 +99,18 @@ void update_write_memory_pattern(uint64_t item, char * buf, size_t bytes, int ra
   uint64_t * buffi = (uint64_t*) buf;
 
   if (dataPacketType == DATA_RANDOM) {
+      uint64_t rand_state_local = rand_state;
       if (!rand_state_init) {
           unsigned seed = rand_seed + pretendRank;
           rand_state_init = 1;
-          rand_state = rand_r(&seed);
+          rand_state_local = rand_r(&seed);
       }
       for (size_t i = 0; i < size; i++) {
-          rand_state *= RANDALGO_GOLDEN_RATIO_PRIME;
-          rand_state >>= 3;
-          buffi[i] = rand_state;
+          rand_state_local *= RANDALGO_GOLDEN_RATIO_PRIME;
+          rand_state_local >>= 3;
+          buffi[i] = rand_state_local;
       }
+      rand_state = rand_state_local;
       return;
   }
 


### PR DESCRIPTION
This branch supports full block scrambling using the [golden prime method implemented in elbencho](https://github.com/breuner/elbencho/blob/master/source/toolkits/random/RandAlgoGoldenPrime.h#L39).  I verified that the resulting file is much less compressible than the "incompressible" data packet type.  For example, writing a 1 MiB file in 4 KiB blocks, then gzipping it (default parameters) results in the following compressed sizes:

- 10772 bytes for `-l incompressible` in ior-3.3
- 11470 bytes for `-l incompressible` in master (commit a436395)
- 1045698 bytes for `-l random` in this branch

There is a lot missing from this branch so far:

- [x] confirmation that this datapackettype is supported in mdtest and md-workbench
- [x] confirmation that `ior -h` reports it as an option (should probably check mdtest and md-workbench too)
- [x] quantification of performance regression with this datapackettype - there probably is some
- [ ] updated documentation
- [ ] add this datapackettype to the travis tester
- [ ] sanity checks for different compilers and platforms

I opened this WIP PR just so I don't lose track of progress here.