### PR TITLE
IOR: fix overflow in offset calculations

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1679,7 +1679,7 @@ static void prefillSegment(IOR_param_t *test, void * randomPrefillBuffer, int pr
   IOR_offset_t transferCount;
   int errors;
   ioBuffers->buffer = randomPrefillBuffer;
-  for (int i = startSegment; i < endSegment; i++){
+  for (IOR_offset_t i = startSegment; i < endSegment; i++){
     for (int j = 0; j < offsets; j++) {
       IOR_offset_t offset = j * test->randomPrefillBlocksize;
       if (test->filePerProc) {
@@ -1707,7 +1707,7 @@ static IOR_offset_t WriteOrRead(IOR_param_t *test, IOR_results_t *results,
         IOR_offset_t dataMoved = 0;     /* for data rate calculation */
         double startForStonewall;
         int hitStonewall;
-        int i, j;
+        IOR_offset_t i, j;
         IOR_point_t *point = ((access == WRITE) || (access == WRITECHECK)) ?
                              &results->write : &results->read;
 


### PR DESCRIPTION
https://github.com/hpc/ior/blob/03f72b4b7ca32597ded6f9b69b0ee4e7125cfa10/src/ior.c#L1688
https://github.com/hpc/ior/blob/03f72b4b7ca32597ded6f9b69b0ee4e7125cfa10/src/ior.c#L1764
https://github.com/hpc/ior/blob/03f72b4b7ca32597ded6f9b69b0ee4e7125cfa10/src/ior.c#L1771
https://github.com/hpc/ior/blob/03f72b4b7ca32597ded6f9b69b0ee4e7125cfa10/src/ior.c#L1825
https://github.com/hpc/ior/blob/03f72b4b7ca32597ded6f9b69b0ee4e7125cfa10/src/ior.c#L1832

In expression `i * test->numTasks`, both operands are **int** type.
It will overflow 32 bits when the `segmentCount` and `numTasks` are large enough.