### PR TITLE
mdtest: make sure fileperproc is set for mdtest read

### DIFF
--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -719,6 +719,8 @@ void mdtest_read(int random, int dirs, const long dir_iter, char *path) {
         /* below temp used to be hiername */
         VERBOSE(3,5,"mdtest_read file: %s", item);
 
+        o.hints.filePerProc = ! o.shared_file;
+
         /* open file for reading */
         aiori_fh = o.backend->open (item, O_RDONLY, o.backend_options);
         if (NULL == aiori_fh) {


### PR DESCRIPTION
When running mdtest create + read, fileperproc is set properly so
the driver known it's not a single shared file. But when mdtest is
running with only read (-E) with a pre-existing dataset, fileperproc
is never set, and driver thinks it's a single shared file and can
do optimization to share the file handle.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>