### PR TITLE
aiori-POSIX: Add new IBM Spectrum Scale specific options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,7 @@ AS_IF([test "$ac_cv_header_gpfs_h" = "yes" -o "$ac_cv_header_gpfs_fcntl_h" = "ye
         AC_SEARCH_LIBS([gpfs_fcntl], [gpfs], [],
         [AC_MSG_ERROR([Library containing gpfs_fcntl symbols not found])
         ])
+        AC_CHECK_TYPES([gpfsFineGrainWriteSharing_t], [], [], [[#include <gpfs_fcntl.h>]])
     ])
 ])
 

--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -357,11 +357,17 @@ LUSTRE-SPECIFIC:
 
 GPFS-SPECIFIC:
 ================
-  * gpfsHintAccess       - use gpfs_fcntl hints to pre-declare accesses
+  --posix.gpfs.hintaccess              - use gpfs_fcntl hints to pre-declare accesses
 
-  * gpfsReleaseToken     - immediately after opening or creating file, release
-			   all locks.  Might help mitigate lock-revocation
-			   traffic when many processes write/read to same file.
+  --posix.gpfs.releasetoken            - immediately after opening or creating file, release
+                                         all locks.  Might help mitigate lock-revocation
+                                         traffic when many processes write/read to same file.
+
+  --posix.gpfs.finegrainwritesharing   - This hint optimizes the performance of small strided
+                                         writes to a shared file from a parallel application
+
+  --posix.gpfs.finegrainreadsharing    - This hint optimizes the performance of small strided
+                                         reads from a shared file from a parallel application
 
 BeeGFS-SPECIFIC (POSIX only):
 ================

--- a/src/aiori-POSIX.h
+++ b/src/aiori-POSIX.h
@@ -19,6 +19,9 @@ typedef struct{
   int gpfs_hint_access;          /* use gpfs "access range" hint */
   int gpfs_release_token;        /* immediately release GPFS tokens after
                                     creating or opening a file */
+  int gpfs_finegrain_writesharing;  /* Enable fine grain write sharing */
+  int gpfs_finegrain_readsharing;   /* Enable fine grain read sharing */
+
   /* beegfs variables */
   int beegfs_numTargets;           /* number storage targets to use */
   int beegfs_chunkSize;            /* srtipe pattern for new files */


### PR DESCRIPTION
Add below options to IOR and mdtest to optimize performance on IBM
Spectrum Scale 5.1.2 and later releases.

finegrainwritesharing: This hint optimizes the performance of small strided
                       writes to a shared file from a parallel application

finegrainreadsharing:  This hint optimizes the performance of small strided
                       reads from a shared file from a parallel application

Fixes https://github.com/hpc/ior/issues/390

Signed-off-by: Pidad D'Souza <pidsouza@in.ibm.com>