### PR TITLE
ior.c: Allow for block/transfer size < 8 bytes

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1574,12 +1574,8 @@ static void ValidateTests(IOR_param_t * test, MPI_Comm com)
                 ERR("using readCheck only requires to write a timeStampSignature -- use -G");
         if (test->segmentCount < 0)
                 ERR("segment count must be positive value");
-        if ((test->blockSize % sizeof(IOR_size_t)) != 0)
-                ERR("block size must be a multiple of access size");
         if (test->blockSize < 0)
                 ERR("block size must be non-negative integer");
-        if ((test->transferSize % sizeof(IOR_size_t)) != 0)
-                ERR("transfer size must be a multiple of access size");
         if (test->transferSize < 0)
                 ERR("transfer size must be non-negative integer");
         if (test->transferSize == 0) {


### PR DESCRIPTION
There is a restriction where the minimum block/transfer size is
8 bytes for all the underlying APIs. I believe this check is not
required, especially as specific APIs already have their own check
for blockSize < sizeof(IOR_size_t) and transferSize < sizeof(IOR_size_t)
few lines below the removed lines.

This patch removes this restriction and let the underlying API
check for their own constraints. That allows to benchmark storage
systems with block sizes lower than 8 bytes if supported.