### PR TITLE
fixed example used in make check

### DIFF
--- a/src/test/example.c
+++ b/src/test/example.c
@@ -7,9 +7,10 @@
 // make distcheck
 // build a single test via, e.g., mpicc example.c -I ../src/ ../src/libaiori.a -lm
 
-int main(){
+int main(int argc, char** argv) {
+  MPI_Init(&argc, &argv);
   IOR_param_t test;
-  init_IOR_Param_t(& test);
+  init_IOR_Param_t(& test, MPI_COMM_WORLD);
   test.blockSize = 10;
   test.transferSize = 10;
   test.segmentCount = 5;
@@ -19,5 +20,6 @@ int main(){
   test.filePerProc = 1;
 
   printf("OK\n");
+  MPI_Finalize();
   return 0;
 }


### PR DESCRIPTION
This PR simply fixes the example.c file, which seems to have been using an older version of `init_IOR_Param_t` that did not require an MPI communicator.