### PR TITLE
Port CEPHFS module to current AIORI API, add Lazy I/O support, and Manila support.

### DIFF
--- a/src/aiori-CEPHFS.c
+++ b/src/aiori-CEPHFS.c
@@ -18,6 +18,7 @@
 # include "config.h"
 #endif
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -63,21 +64,24 @@ static struct ceph_mount_info *cmount;
 /**************************** P R O T O T Y P E S *****************************/
 static void CEPHFS_Init();
 static void CEPHFS_Final();
-static void *CEPHFS_Create(char *, IOR_param_t *);
-static void *CEPHFS_Open(char *, IOR_param_t *);
-static IOR_offset_t CEPHFS_Xfer(int, void *, IOR_size_t *,
-                           IOR_offset_t, IOR_param_t *);
-static void CEPHFS_Close(void *, IOR_param_t *);
-static void CEPHFS_Delete(char *, IOR_param_t *);
-static void CEPHFS_Fsync(void *, IOR_param_t *);
-static IOR_offset_t CEPHFS_GetFileSize(IOR_param_t *, MPI_Comm, char *);
-static int CEPHFS_StatFS(const char *, ior_aiori_statfs_t *, IOR_param_t *);
-static int CEPHFS_MkDir(const char *, mode_t, IOR_param_t *);
-static int CEPHFS_RmDir(const char *, IOR_param_t *);
-static int CEPHFS_Access(const char *, int, IOR_param_t *);
-static int CEPHFS_Stat(const char *, struct stat *, IOR_param_t *);
-static void CEPHFS_Sync(IOR_param_t *);
+void CEPHFS_xfer_hints(aiori_xfer_hint_t * params);
+static aiori_fd_t *CEPHFS_Create(char *path, int flags, aiori_mod_opt_t *options);
+static aiori_fd_t *CEPHFS_Open(char *path, int flags, aiori_mod_opt_t *options);
+static IOR_offset_t CEPHFS_Xfer(int access, aiori_fd_t *file, IOR_size_t *buffer,
+                           IOR_offset_t length, IOR_offset_t offset, aiori_mod_opt_t *options);
+static void CEPHFS_Close(aiori_fd_t *, aiori_mod_opt_t *);
+static void CEPHFS_Delete(char *path, aiori_mod_opt_t *);
+static void CEPHFS_Fsync(aiori_fd_t *, aiori_mod_opt_t *);
+static IOR_offset_t CEPHFS_GetFileSize(aiori_mod_opt_t *, char *);
+static int CEPHFS_StatFS(const char *path, ior_aiori_statfs_t *stat, aiori_mod_opt_t *options);
+static int CEPHFS_MkDir(const char *path, mode_t mode, aiori_mod_opt_t *options);
+static int CEPHFS_RmDir(const char *path, aiori_mod_opt_t *options);
+static int CEPHFS_Access(const char *path, int mode, aiori_mod_opt_t *options);
+static int CEPHFS_Stat(const char *path, struct stat *buf, aiori_mod_opt_t *options);
+static void CEPHFS_Sync(aiori_mod_opt_t *);
 static option_help * CEPHFS_options();
+
+static aiori_xfer_hint_t * hints = NULL;
 
 /************************** D E C L A R A T I O N S ***************************/
 ior_aiori_t cephfs_aiori = {
@@ -90,7 +94,9 @@ ior_aiori_t cephfs_aiori = {
         .xfer = CEPHFS_Xfer,
         .close = CEPHFS_Close,
         .delete = CEPHFS_Delete,
+        .get_options = CEPHFS_options,
         .get_version = aiori_get_version,
+        .xfer_hints = CEPHFS_xfer_hints,
         .fsync = CEPHFS_Fsync,
         .get_file_size = CEPHFS_GetFileSize,
         .statfs = CEPHFS_StatFS,
@@ -99,7 +105,6 @@ ior_aiori_t cephfs_aiori = {
         .access = CEPHFS_Access,
         .stat = CEPHFS_Stat,
         .sync = CEPHFS_Sync,
-        .get_options = CEPHFS_options,
 };
 
 #define CEPHFS_ERR(__err_str, __ret) do { \
@@ -108,6 +113,12 @@ ior_aiori_t cephfs_aiori = {
 } while(0)
 
 /***************************** F U N C T I O N S ******************************/
+
+void CEPHFS_xfer_hints(aiori_xfer_hint_t * params)
+{
+  hints = params;
+}
+
 static const char* pfix(const char* path) {
         const char* npath = path;
         const char* prefix = o.prefix;
@@ -150,7 +161,7 @@ static void CEPHFS_Init()
         }
 
         /* mount the handle */
-        ret = ceph_mount(cmount, "/");
+        ret = ceph_mount(cmount, o.prefix);
         if (ret) {
                 CEPHFS_ERR("unable to mount cephfs", ret);
                 ceph_shutdown(cmount);
@@ -184,55 +195,55 @@ static void CEPHFS_Final()
 	cmount = NULL;
 }
 
-static void *CEPHFS_Create(char *testFileName, IOR_param_t * param)
+static aiori_fd_t *CEPHFS_Create(char *path, int flags, aiori_mod_opt_t *options)
 {
-        return CEPHFS_Open(testFileName, param);
+        return CEPHFS_Open(path, flags | IOR_CREAT, options);
 }
 
-static void *CEPHFS_Open(char *testFileName, IOR_param_t * param)
+static aiori_fd_t *CEPHFS_Open(char *path, int flags, aiori_mod_opt_t *options)
 {
-        const char *file = pfix(testFileName);
+        const char *file = pfix(path);
         int* fd;
         fd = (int *)malloc(sizeof(int));
 
         mode_t mode = 0664;
-        int flags = (int) 0;
+        int ceph_flags = (int) 0;
 
         /* set IOR file flags to CephFS flags */
         /* -- file open flags -- */
-        if (param->openFlags & IOR_RDONLY) {
-                flags |= CEPH_O_RDONLY;
+        if (flags & IOR_RDONLY) {
+                ceph_flags |= CEPH_O_RDONLY;
         }
-        if (param->openFlags & IOR_WRONLY) {
-                flags |= CEPH_O_WRONLY;
+        if (flags & IOR_WRONLY) {
+                ceph_flags |= CEPH_O_WRONLY;
         }
-        if (param->openFlags & IOR_RDWR) {
-                flags |= CEPH_O_RDWR;
+        if (flags & IOR_RDWR) {
+                ceph_flags |= CEPH_O_RDWR;
         }
-        if (param->openFlags & IOR_APPEND) {
-                fprintf(stdout, "File append not implemented in CephFS\n");
+        if (flags & IOR_APPEND) {
+                CEPHFS_ERR("File append not implemented in CephFS", EINVAL);
         }
-        if (param->openFlags & IOR_CREAT) {
-                flags |= CEPH_O_CREAT;
+        if (flags & IOR_CREAT) {
+                ceph_flags |= CEPH_O_CREAT;
         }
-        if (param->openFlags & IOR_EXCL) {
-                flags |= CEPH_O_EXCL;
+        if (flags & IOR_EXCL) {
+                ceph_flags |= CEPH_O_EXCL;
         }
-        if (param->openFlags & IOR_TRUNC) {
-                flags |= CEPH_O_TRUNC;
+        if (flags & IOR_TRUNC) {
+                ceph_flags |= CEPH_O_TRUNC;
         }
-        if (param->openFlags & IOR_DIRECT) {
-                fprintf(stdout, "O_DIRECT not implemented in CephFS\n");
+        if (flags & IOR_DIRECT) {
+                CEPHFS_ERR("O_DIRECT not implemented in CephFS", EINVAL);
         }
-        *fd = ceph_open(cmount, file, flags, mode);
+        *fd = ceph_open(cmount, file, ceph_flags, mode);
         if (*fd < 0) {
                 CEPHFS_ERR("ceph_open failed", *fd);
         }
         return (void *) fd;
 }
 
-static IOR_offset_t CEPHFS_Xfer(int access, void *file, IOR_size_t * buffer,
-                               IOR_offset_t length, IOR_param_t * param)
+static IOR_offset_t CEPHFS_Xfer(int access, aiori_fd_t *file, IOR_size_t *buffer,
+                           IOR_offset_t length, IOR_offset_t offset, aiori_mod_opt_t *options)
 {
         uint64_t size = (uint64_t) length;
         char *buf = (char *) buffer;
@@ -241,19 +252,19 @@ static IOR_offset_t CEPHFS_Xfer(int access, void *file, IOR_size_t * buffer,
 
         if (access == WRITE)
         {
-                ret = ceph_write(cmount, fd, buf, size, param->offset);
+                ret = ceph_write(cmount, fd, buf, size, offset);
                 if (ret < 0) {
                         CEPHFS_ERR("unable to write file to CephFS", ret);
                 } else if (ret < size) {
                         CEPHFS_ERR("short write to CephFS", ret);
                 }
-                if (param->fsyncPerWrite == TRUE) {
-                        CEPHFS_Fsync(&fd, param);
+                if (hints->fsyncPerWrite == TRUE) {
+                        CEPHFS_Fsync(file, options);
                 }
         }
         else /* READ */
         {
-                ret = ceph_read(cmount, fd, buf, size, param->offset);
+                ret = ceph_read(cmount, fd, buf, size, offset);
                 if (ret < 0) {
                         CEPHFS_ERR("unable to read file from CephFS", ret);
                 } else if (ret < size) {
@@ -264,7 +275,7 @@ static IOR_offset_t CEPHFS_Xfer(int access, void *file, IOR_size_t * buffer,
         return length;
 }
 
-static void CEPHFS_Fsync(void *file, IOR_param_t * param)
+static void CEPHFS_Fsync(aiori_fd_t *file, aiori_mod_opt_t *options)
 {
         int fd = *(int *) file;
         int ret = ceph_fsync(cmount, fd, 0);
@@ -273,7 +284,7 @@ static void CEPHFS_Fsync(void *file, IOR_param_t * param)
         }
 }
 
-static void CEPHFS_Close(void *file, IOR_param_t * param)
+static void CEPHFS_Close(aiori_fd_t *file, aiori_mod_opt_t *options)
 {
         int fd = *(int *) file;
         int ret = ceph_close(cmount, fd);
@@ -284,28 +295,27 @@ static void CEPHFS_Close(void *file, IOR_param_t * param)
         return;
 }
 
-static void CEPHFS_Delete(char *testFileName, IOR_param_t * param)
+static void CEPHFS_Delete(char *path, aiori_mod_opt_t *options)
 {
-        int ret = ceph_unlink(cmount, pfix(testFileName));
+        int ret = ceph_unlink(cmount, pfix(path));
         if (ret < 0) {
                 CEPHFS_ERR("ceph_unlink failed", ret);
         }
         return;
 }
 
-static IOR_offset_t CEPHFS_GetFileSize(IOR_param_t * param, MPI_Comm testComm,
-                                      char *testFileName)
+static IOR_offset_t CEPHFS_GetFileSize(aiori_mod_opt_t *options, char *path)
 {
         struct stat stat_buf;
         IOR_offset_t aggFileSizeFromStat, tmpMin, tmpMax, tmpSum;
 
-        int ret = ceph_stat(cmount, pfix(testFileName), &stat_buf);
+        int ret = ceph_stat(cmount, pfix(path), &stat_buf);
         if (ret < 0) {
                 CEPHFS_ERR("ceph_stat failed", ret);
         }
         aggFileSizeFromStat = stat_buf.st_size;
 
-        if (param->filePerProc == TRUE) {
+        if (hints->filePerProc == TRUE) {
                 MPI_CHECK(MPI_Allreduce(&aggFileSizeFromStat, &tmpSum, 1,
                                         MPI_LONG_LONG_INT, MPI_SUM, testComm),
                           "cannot total data moved");
@@ -327,11 +337,9 @@ static IOR_offset_t CEPHFS_GetFileSize(IOR_param_t * param, MPI_Comm testComm,
         }
 
         return (aggFileSizeFromStat);
-
 }
 
-static int CEPHFS_StatFS(const char *path, ior_aiori_statfs_t *stat_buf,
-                        IOR_param_t *param)
+static int CEPHFS_StatFS(const char *path, ior_aiori_statfs_t *stat_buf, aiori_mod_opt_t *options)
 {
 #if defined(HAVE_STATVFS)
         struct statvfs statfs_buf;
@@ -354,28 +362,28 @@ static int CEPHFS_StatFS(const char *path, ior_aiori_statfs_t *stat_buf,
 #endif
 }
 
-static int CEPHFS_MkDir(const char *path, mode_t mode, IOR_param_t *param)
+static int CEPHFS_MkDir(const char *path, mode_t mode, aiori_mod_opt_t *options)
 {
         return ceph_mkdir(cmount, pfix(path), mode);
 }
 
-static int CEPHFS_RmDir(const char *path, IOR_param_t *param)
+static int CEPHFS_RmDir(const char *path, aiori_mod_opt_t *options)
 {
         return ceph_rmdir(cmount, pfix(path));
 }
 
-static int CEPHFS_Access(const char *testFileName, int mode, IOR_param_t *param)
+static int CEPHFS_Access(const char *path, int mode, aiori_mod_opt_t *options)
 {
         struct stat buf;
-        return ceph_stat(cmount, pfix(testFileName), &buf);
+        return ceph_stat(cmount, pfix(path), &buf);
 }
 
-static int CEPHFS_Stat(const char *testFileName, struct stat *buf, IOR_param_t *param)
+static int CEPHFS_Stat(const char *path, struct stat *buf, aiori_mod_opt_t *options)
 {
-        return ceph_stat(cmount, pfix(testFileName), buf);
+        return ceph_stat(cmount, pfix(path), buf);
 }
 
-static void CEPHFS_Sync(IOR_param_t *param)
+static void CEPHFS_Sync(aiori_mod_opt_t *options)
 {
         int ret = ceph_sync_fs(cmount);
         if (ret < 0) {

--- a/src/aiori-CEPHFS.c
+++ b/src/aiori-CEPHFS.c
@@ -44,6 +44,7 @@ struct cephfs_options{
   char * user;
   char * conf;
   char * prefix;
+  char * remote_prefix;
   int olazy;
 };
 
@@ -51,13 +52,15 @@ static struct cephfs_options o = {
   .user = NULL,
   .conf = NULL,
   .prefix = NULL,
+  .remote_prefix = NULL,
   .olazy = 0,
 };
 
 static option_help options [] = {
       {0, "cephfs.user", "Username for the ceph cluster", OPTION_REQUIRED_ARGUMENT, 's', & o.user},
       {0, "cephfs.conf", "Config file for the ceph cluster", OPTION_REQUIRED_ARGUMENT, 's', & o.conf},
-      {0, "cephfs.prefix", "mount prefix", OPTION_OPTIONAL_ARGUMENT, 's', & o.prefix},
+      {0, "cephfs.prefix", "Mount prefix", OPTION_OPTIONAL_ARGUMENT, 's', & o.prefix},
+      {0, "cephfs.remote_prefix", "Remote mount prefix", OPTION_OPTIONAL_ARGUMENT, 's', & o.remote_prefix},
       {0, "cephfs.olazy", "Enable Lazy I/O", OPTION_FLAG, 'd', & o.olazy},
       LAST_OPTION
 };
@@ -139,10 +142,15 @@ static option_help * CEPHFS_options(){
 
 static void CEPHFS_Init()
 {
+        char *remote_prefix = "/";
+
         /* Short circuit if the options haven't been filled yet. */
         if (!o.user || !o.conf || !o.prefix) {
                 WARN("CEPHFS_Init() called before options have been populated!");
                 return;
+        }
+        if (o.remote_prefix != NULL) {
+                remote_prefix = o.remote_prefix;
         }
 
         /* Short circuit if the mount handle already exists */ 
@@ -164,7 +172,7 @@ static void CEPHFS_Init()
         }
 
         /* mount the handle */
-        ret = ceph_mount(cmount, o.prefix);
+        ret = ceph_mount(cmount, remote_prefix);
         if (ret) {
                 CEPHFS_ERR("unable to mount cephfs", ret);
                 ceph_shutdown(cmount);


### PR DESCRIPTION
This MR makes three contributions:

1. Port CEPHFS to current AIORI API, as it was not compiling anymore. (#393be78)
2. Add Lazy I/O support via a new, optional `--cephfs.olazy` flag. (#1e34b3e)
3. Add a remote mount prefix option. This is necessary for multi-tenancy users such as OpenStack Manila, where the root filesystem is not being mounted, but a volume subpath (our remote_prefix option) is mounted instead. (#53eb94f)

Notably, enabling Lazy I/O enables much better performance for single shared file collective I/O (IO500's ior hard mode):

With `--ceph.olazy`:
```
Summary of all tests:
Operation   Max(MiB)   Min(MiB)  Mean(MiB)     StdDev   Max(OPs)   Min(OPs)  Mean(OPs)     StdDev    Mean(s) Stonewall(s) Stonewall(MiB) Test# #Tasks tPN reps fPP reord reordoff reordrand seed segcnt   blksiz    xsize aggs(MiB)   API RefNum
write        3645.52    3645.52    3645.52       0.00    1822.76    1822.76    1822.76       0.00   32.91714         NA            NA     0      6   1    1   0     1        1         0    0  10000  2097152  2097152  120000.0 CEPHFS      0
```

Without:
```
Summary of all tests:                                                                                                             
Operation   Max(MiB)   Min(MiB)  Mean(MiB)     StdDev   Max(OPs)   Min(OPs)  Mean(OPs)     StdDev    Mean(s) Stonewall(s) Stonewall(MiB) Test# #Tasks tPN reps fPP reord reordoff reordrand seed segcnt   blksiz    xsize aggs(MiB)   API RefNum
write         575.31     575.31     575.31       0.00     287.66     287.66     287.66       0.00  208.58290         NA            NA     0      6   1    1   0     1        1         0    0  10000  2097152  2097152  120000.0 CEPHFS      0
```

(Note that in order to compile this, one still needs to patch libcephfs.h to add `#include <sys/time.h>`. This seems to be a problem that's of course external to IOR)