### PR TITLE
bugfix: CEPHFS: Make all module parameters optional

### DIFF
--- a/src/aiori-CEPHFS.c
+++ b/src/aiori-CEPHFS.c
@@ -57,8 +57,8 @@ static struct cephfs_options o = {
 };
 
 static option_help options [] = {
-      {0, "cephfs.user", "Username for the ceph cluster", OPTION_REQUIRED_ARGUMENT, 's', & o.user},
-      {0, "cephfs.conf", "Config file for the ceph cluster", OPTION_REQUIRED_ARGUMENT, 's', & o.conf},
+      {0, "cephfs.user", "Username for the ceph cluster", OPTION_OPTIONAL_ARGUMENT, 's', & o.user},
+      {0, "cephfs.conf", "Config file for the ceph cluster", OPTION_OPTIONAL_ARGUMENT, 's', & o.conf},
       {0, "cephfs.prefix", "Mount prefix", OPTION_OPTIONAL_ARGUMENT, 's', & o.prefix},
       {0, "cephfs.remote_prefix", "Remote mount prefix", OPTION_OPTIONAL_ARGUMENT, 's', & o.remote_prefix},
       {0, "cephfs.olazy", "Enable Lazy I/O", OPTION_FLAG, 'd', & o.olazy},


### PR DESCRIPTION
Unless I misunderstood the way AIORI works, it seems that `OPTION_REQUIRED_ARGUMENT` is not a per-module setting, but is global.
Therefore switch these options that were as REQUIRED to OPTIONAL. Otherwise, `ior` refuses to run, even when not using `-a CEPHFS`, unless these cephfs-specific options are provided.

The cephfs module does have a check in the initialization function to verify whether some argument that it requires are present or not, so this should be fine.

BTW, some grepping revealed that the same issue might also be present for the RADOS module.