### PR TITLE
Use the EXIT_FAIlURE for exit() on error

### DIFF
--- a/src/aiori-DFS.c
+++ b/src/aiori-DFS.c
@@ -808,7 +808,7 @@ DFS_Xfer(int access, aiori_fd_t *file, IOR_size_t *buffer, IOR_offset_t length,
 
                 if (ret < remaining) {
                         if (hints->singleXferAttempt == TRUE)
-                                exit(-1);
+                                exit(EXIT_FAILURE);
                         if (xferRetries > MAX_RETRY)
                                 ERR("too many retries -- aborting");
                 }

--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -60,7 +60,7 @@
         if (strcmp(resultString, "Invalid minor error number") != 0)     \
             fprintf(stdout, "%s\n", resultString);                       \
         fprintf(stdout, "** exiting **\n");                              \
-        exit(-1);                                                        \
+        exit(EXIT_FAILURE);                                                        \
     }                                                                    \
 } while(0)
 #else                           /* ! (H5_VERS_MAJOR > 1 && H5_VERS_MINOR > 6) */
@@ -75,7 +75,7 @@
          *            char* mesg, size_t size)                           \
          */                                                              \
         fprintf(stdout, "** exiting **\n");                              \
-        exit(-1);                                                        \
+        exit(EXIT_FAILURE);                                                        \
     }                                                                    \
 } while(0)
 #endif                          /* H5_VERS_MAJOR > 1 && H5_VERS_MINOR > 6 */

--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -39,7 +39,7 @@
                 __FILE__, __LINE__, MSG);                                \
         fprintf(stdout, "ERROR: %s.\n", ncmpi_strerror(NCMPI_RETURN));   \
         fprintf(stdout, "** exiting **\n");                              \
-        exit(-1);                                                        \
+        exit(EXIT_FAILURE);                                                        \
     }                                                                    \
 } while(0)
 

--- a/src/aiori-S3-4c.c
+++ b/src/aiori-S3-4c.c
@@ -841,7 +841,7 @@ static IOR_offset_t S3_Xfer_internal(int          access,
          if (strlen(param->io_buf->eTag) != ETAG_SIZE+2) { /* quotes at both ends */
 					fprintf(stderr, "Rank %d: ERROR: expected ETag to be %d hex digits\n",
 							  rank, ETAG_SIZE);
-					exit(1);
+					exit(EXIT_FAILURE);
          }
 
 			// save the eTag for later

--- a/src/md-workbench.c
+++ b/src/md-workbench.c
@@ -851,12 +851,12 @@ static int return_position(){
     FILE * f = fopen(o.run_info_file, "r");
     if(! f){
       ERRF("[ERROR] Could not open %s for restart", o.run_info_file);
-      exit(1);
+      exit(EXIT_FAILURE);
     }
     ret = fscanf(f, "pos: %d", & position);
     if (ret != 1){
       ERRF("Could not read from %s for restart", o.run_info_file);
-      exit(1);
+      exit(EXIT_FAILURE);
     }
     fclose(f);
   }
@@ -871,7 +871,7 @@ static void store_position(int position){
   FILE * f = fopen(o.run_info_file, "w");
   if(! f){
     ERRF("[ERROR] Could not open %s for saving data", o.run_info_file);
-    exit(1);
+    exit(EXIT_FAILURE);
   }
   fprintf(f, "pos: %d\n", position);
   fclose(f);

--- a/src/option.c
+++ b/src/option.c
@@ -315,7 +315,7 @@ static void option_parse_token(char ** argv, int * flag_parsed_next, int * requi
               if(arg == NULL){
                 const char str[] = {o->shortVar, 0};
                 printf("Error, argument missing for option %s\n", (o->longVar != NULL) ? o->longVar : str);
-                exit(1);
+                exit(EXIT_FAILURE);
               }
 
               switch(o->type){
@@ -460,7 +460,7 @@ int option_parse(int argc, char ** argv, options_all_t * opt_all){
       }
       option_print_help(args);
     }
-    exit(0);
+    exit(EXIT_FAILURE);
   }
 
   return i;

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -95,7 +95,7 @@ void DecodeDirective(char *line, IOR_param_t *params, options_all_t * module_opt
                 if (initialized)
                     MPI_CHECK(MPI_Abort(MPI_COMM_WORLD, -1), "MPI_Abort() error");
                 else
-                    exit(-1);
+                    exit(EXIT_FAILURE);
         }
         if (strcasecmp(option, "api") == 0) {
           params->api = strdup(value);
@@ -103,7 +103,7 @@ void DecodeDirective(char *line, IOR_param_t *params, options_all_t * module_opt
           params->backend = aiori_select(params->api);
           if (params->backend == NULL){
             fprintf(out_logfile, "Could not load backend API %s\n", params->api);
-            exit(-1);
+            exit(EXIT_FAILURE);
           }
         } else if (strcasecmp(option, "summaryFile") == 0) {
           if (rank == 0){
@@ -258,7 +258,7 @@ void DecodeDirective(char *line, IOR_param_t *params, options_all_t * module_opt
                   if (initialized)
                       MPI_CHECK(MPI_Abort(MPI_COMM_WORLD, -1), "MPI_Abort() error");
                   else
-                      exit(-1);
+                      exit(EXIT_FAILURE);
                 }
         }
 }
@@ -285,7 +285,7 @@ void ParseLine(char *line, IOR_param_t * test, options_all_t * module_options)
                 }
                 if(strlen(start) < 3){
                   fprintf(out_logfile, "Invalid option substring string: \"%s\" in \"%s\"\n", start, line);
-                  exit(1);
+                  exit(EXIT_FAILURE);
                 }
                 DecodeDirective(start, test, module_options);
                 start = end + 1;


### PR DESCRIPTION
Hi,

This PR changes all exit codes of `exit()` in the case of error to the `EXIT_FAILURE` macro.
The main reason for that was [this line](https://github.com/hpc/ior/blob/main/src/option.c#L463), which falsely was calling `exit(0)` in the case of invalid arguments. This is disadvantageous in combination with job scheduler like slurm that will report the job as successfully completed when exit with 0.
Because all other calls to `exit()` return 1 or -1 with no obvious pattern I decided to change all exit return codes to the `EXIT_FAILURE` macro. 
