### PR TITLE
use AM_LDFLAGS instead of LDFLAGS

### DIFF
--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -1,4 +1,4 @@
-LDFLAGS  = $(extraLDFLAGS)
+AM_LDFLAGS = $(extraLDFLAGS)
 LDADD    = ../libaiori.a $(extraLDADD)
 
 # Add test here


### PR DESCRIPTION
Without this patch, command "make check" fails when LDFLAGS environment
variable is set at configure.