### PR TITLE
Update Documentation, Improve HDF5 Backend, Unify Debug Macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,8 @@ AC_ARG_WITH([lustre],
                 [support configurable Lustre striping values @<:@default=check@:>@])],
         [], [with_lustre=check])
 AS_IF([test "x$with_lustre" = xyes ], [
-        AC_CHECK_HEADERS([linux/lustre/lustre_user.h lustre/lustre_user.h], [AC_DEFINE([HAVE_LUSTRE_USER], [], [Lustre user API available in some shape or form])], [
+        AC_CHECK_HEADERS([linux/lustre/lustre_user.h lustre/lustre_user.h],
+                [AC_DEFINE([HAVE_LUSTRE_USER], [], [Lustre user API available in some shape or form])], [
                 if test "x$with_lustre" != xcheck -a \
                         "x$ac_cv_header_linux_lustre_lustre_user_h" = "xno" -a \
                         "x$ac_cv_header_lustre_lustre_user_h" = "xno" ; then

--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -89,7 +89,7 @@ These options are to be used on the command line. E.g., 'IOR -a POSIX -b 4K'.
   -n    noFill -- no fill in HDF5 file creation
   -N N  numTasks -- number of tasks that should participate in the test
   -o S  testFile -- full name for test
-  -O S  string of IOR directives (e.g. -O checkRead=1,lustreStripeCount=32)
+  -O S  string of IOR directives (e.g. -O checkRead=1,GPUid=2)
   -p    preallocate -- preallocate file size
   -P    useSharedFilePointer -- use shared file pointer [not working]
   -q    quitOnError -- during file error-checking, abort on error
@@ -347,34 +347,54 @@ MPIIO-, HDF5-, AND NCMPI-ONLY:
 
 LUSTRE-SPECIFIC:
 ================
-  * lustreStripeCount    - set the lustre stripe count for the test file(s) [0]
+  * POSIX-ONLY:
+    * --posix.lustre.stripecount  - set the Lustre stripe count for the test file(s) [0]
 
-  * lustreStripeSize     - set the lustre stripe size for the test file(s) [0]
+    * --posix.lustre.stripesize   - set the Lustre stripe size for the test file(s) [0]
 
-  * lustreStartOST       - set the starting OST for the test file(s) [-1]
+    * --posix.lustre.startost     - set the starting OST for the test file(s) [-1]
 
-  * lustreIgnoreLocks    - disable lustre range locking [0]
+    * --posix.lustre.ignorelocks - disable Lustre range locking [0]
 
-GPFS-SPECIFIC:
+  * MPIIO-, HDF5-, AND NCMPI-ONLY:
+    * ROMIO-based IO (see https://github.com/pmodels/mpich/blob/048879f1234419abb035aacbaf655880c8f77dba/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c#L58):
+      * requires setting the environment variable ROMIO_FSTYPE_FORCE=LUSTRE: (or similar for specific MPIs) to enable ROMIO's Lustre ADIO
+
+      * IOR_HINT__MPI__striping_factor - set the Lustre stripe count for the test file(s) [-1]
+
+      * IOR_HINT__MPI__striping_unit - set the Lustre stripe size for the test file(s) [0]
+
+      * IOR_HINT__MPI__romio_lustre_start_iodevice - set the starting OST for the test file(s) [-1]
+
+    * OMPIO-based IO (see https://github.com/open-mpi/ompi/blob/6d237e85d730ed946c9f45fcd3e19b78a243203e/ompi/mca/fs/lustre/fs_lustre_component.c#L75)
+      * not setting either of the environment variables below causes a fatal "Floating point exception: Integer divide-by-zero" error
+
+      * execution with either of the environment variables causes this message "ior: setstripe error for 'testfile': stripe already set" which can safely be ignored as OMPIO tries to modify the stripe settings twice although the first time succeeds
+
+      * OMPI_MCA_fs_lustre_stripe_width / IOR_HINT__MPI__stripe_width - set the Lustre stripe count for the test file(s) [0]
+
+      * OMPI_MCA_fs_lustre_stripe_size / IOR_HINT__MPI__stripe_size - set the Lustre stripe size for the test file(s) [0]
+
+GPFS-SPECIFIC (POSIX-ONLY):
 ================
-  --posix.gpfs.hintaccess              - use gpfs_fcntl hints to pre-declare accesses
+  * --posix.gpfs.hintaccess               - use gpfs_fcntl hints to pre-declare accesses
 
-  --posix.gpfs.releasetoken            - immediately after opening or creating file, release
-                                         all locks.  Might help mitigate lock-revocation
-                                         traffic when many processes write/read to same file.
+  * --posix.gpfs.releasetoken             - immediately after opening or creating file, release
+                                            all locks.  Might help mitigate lock-revocation
+                                            traffic when many processes write/read to same file.
 
-  --posix.gpfs.finegrainwritesharing   - This hint optimizes the performance of small strided
-                                         writes to a shared file from a parallel application
+  * --posix.gpfs.finegrainwritesharing    - This hint optimizes the performance of small strided
+                                            writes to a shared file from a parallel application
 
-  --posix.gpfs.finegrainreadsharing    - This hint optimizes the performance of small strided
-                                         reads from a shared file from a parallel application
+  * --posix.gpfs.finegrainreadsharing     - This hint optimizes the performance of small strided
+                                            reads from a shared file from a parallel application
 
-BeeGFS-SPECIFIC (POSIX only):
+BeeGFS-SPECIFIC (POSIX-ONLY):
 ================
-  * beegfsNumTargets     - set the number of storage targets to use
+  * --posix.beegfs.NumTargets     - set the number of storage targets to use
 
-  * beegfsChunkSize      - set the striping chunk size. Must be a power of two,
-                             and greater than 64kiB, (e.g.: 256k, 1M, ...)
+  * --posix.beegfs.ChunkSize      - set the striping chunk size. Must be a power of two,
+                                    and greater than 64kiB, (e.g.: 256k, 1M, ...)
 
 
 ***********************

--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -181,18 +181,6 @@ static int HDF5_check_params(aiori_mod_opt_t * options){
       ERR("alignment must be non-negative integer");
   if (o->individualDataSets)
       ERR("individual data sets not implemented");
-  if (o->noFill) {
-    /* check if hdf5 available */
-#if defined (H5_VERS_MAJOR) && defined (H5_VERS_MINOR)
-    /* no-fill option not available until hdf5-1.6.x */
-#if (H5_VERS_MAJOR > 0 && H5_VERS_MINOR > 5)
-#else
-    ERR("'no fill' option not available in HDF5");
-#endif
-#else
-    WARN("unable to determine HDF5 version for 'no fill' usage");
-#endif
-  }
   return 0;
 }
 
@@ -273,7 +261,6 @@ static aiori_fd_t *HDF5_Open(char *testFileName, int flags, aiori_mod_opt_t * pa
                 comm = testComm;
         }
 
-        SetHints(&mpiHints, o->hintsFileName);
         /*
          * note that with MP_HINTS_FILTERED=no, all key/value pairs will
          * be in the info object.  The info object that is attached to
@@ -281,6 +268,7 @@ static aiori_fd_t *HDF5_Open(char *testFileName, int flags, aiori_mod_opt_t * pa
          * deemed valid by the implementation.
          */
         /* show hints passed to file */
+        SetHints(&mpiHints, o->hintsFileName);
         if (rank == 0 && o->showHints) {
                 fprintf(stdout, "\nhints passed to access property list {\n");
                 ShowHints(&mpiHints);
@@ -294,7 +282,6 @@ static aiori_fd_t *HDF5_Open(char *testFileName, int flags, aiori_mod_opt_t * pa
                    "cannot set alignment");
 
 #ifdef HAVE_H5PSET_ALL_COLL_METADATA_OPS
-
         if (o->collective_md) {
                 /* more scalable metadata */
 
@@ -317,40 +304,18 @@ static aiori_fd_t *HDF5_Open(char *testFileName, int flags, aiori_mod_opt_t * pa
         }
 
         /* show hints actually attached to file handle */
-        if (o->showHints || (1) /* WEL - this needs fixing */ ) {
-                if (rank == 0 && (o->showHints) /* WEL - this needs fixing */ ) {
-                        WARN("showHints not working for HDF5");
-                }
-        } else {
-                MPI_Info mpiHintsCheck = MPI_INFO_NULL;
-                hid_t apl;
-                apl = H5Fget_access_plist(*fd);
-                HDF5_CHECK(H5Pget_fapl_mpio(apl, &comm, &mpiHintsCheck),
-                           "cannot get info object through HDF5");
+        if (o->showHints) {
+                MPI_File *fd_mpiio;
+                HDF5_CHECK(H5Fget_vfd_handle(*fd, accessPropList, (void **) &fd_mpiio), "cannot get file handle");
+                MPI_Info info_used;
+                MPI_CHECK(MPI_File_get_info(*fd_mpiio, &info_used), "cannot get file info");
                 if (rank == 0) {
-                        fprintf(stdout,
-                                "\nhints returned from opened file (HDF5) {\n");
-                        ShowHints(&mpiHintsCheck);
-                        fprintf(stdout, "}\n");
-                        if (1 == 1) {   /* request the MPIIO file handle and its hints */
-                                MPI_File *fd_mpiio;
-                                HDF5_CHECK(H5Fget_vfd_handle
-                                           (*fd, apl, (void **)&fd_mpiio),
-                                           "cannot get MPIIO file handle");
-                                if (mpiHintsCheck != MPI_INFO_NULL)
-                                        MPI_Info_free(&mpiHintsCheck);
-                                MPI_CHECK(MPI_File_get_info
-                                          (*fd_mpiio, &mpiHintsCheck),
-                                          "cannot get info object through MPIIO");
-                                fprintf(stdout,
-                                        "\nhints returned from opened file (MPIIO) {\n");
-                                ShowHints(&mpiHintsCheck);
+                        /* print the MPI file hints currently used */
+                        fprintf(stdout, "\nhints returned from opened file {\n");
+                        ShowHints(&info_used);
                                 fprintf(stdout, "}\n");
-                                if (mpiHintsCheck != MPI_INFO_NULL)
-                                        MPI_Info_free(&mpiHintsCheck);
                         }
-                }
-                MPI_CHECK(MPI_Barrier(testComm), "barrier error");
+                MPI_CHECK(MPI_Info_free(&info_used), "cannot free file info");
         }
 
         /* this is necessary for resetting various parameters
@@ -499,6 +464,7 @@ static IOR_offset_t HDF5_Xfer(int access, aiori_fd_t *fd, IOR_size_t * buffer,
  */
 static void HDF5_Fsync(aiori_fd_t *fd, aiori_mod_opt_t * param)
 {
+        HDF5_CHECK(H5Fflush(*(hid_t *) fd, H5F_SCOPE_LOCAL), "cannot flush file to disk");
 }
 
 /*
@@ -627,10 +593,6 @@ static void SetupDataSet(void *fd, int flags, aiori_mod_opt_t * param)
         if (flags & IOR_CREAT) {     /* WRITE */
                 /* create data set */
                 dataSetPropList = H5Pcreate(H5P_DATASET_CREATE);
-                /* check if hdf5 available */
-#if defined (H5_VERS_MAJOR) && defined (H5_VERS_MINOR)
-                /* no-fill option not available until hdf5-1.6.x */
-#if (H5_VERS_MAJOR > 0 && H5_VERS_MINOR > 5)
                 if (o->noFill == TRUE) {
                         if (rank == 0 && verbose >= VERBOSE_1) {
                                 fprintf(stdout, "\nusing 'no fill' option\n");
@@ -639,15 +601,6 @@ static void SetupDataSet(void *fd, int flags, aiori_mod_opt_t * param)
                                                     H5D_FILL_TIME_NEVER),
                                    "cannot set fill time for property list");
                 }
-#else
-                char errorString[MAX_STR];
-                sprintf(errorString, "'no fill' option not available in %s",
-                        test->apiVersion);
-                ERR(errorString);
-#endif
-#else
-                WARN("unable to determine HDF5 version for 'no fill' usage");
-#endif
                 dataSet =
                     H5Dcreate(*(hid_t *) fd, dataSetName, H5T_NATIVE_LLONG,
                               dataSpace, dataSetPropList);

--- a/src/aiori-HDFS.c
+++ b/src/aiori-HDFS.c
@@ -78,7 +78,11 @@
 #include <assert.h>
 /*
 #ifdef HAVE_LUSTRE_USER
-#include <lustre/lustre_user.h>
+#  ifdef HAVE_LINUX_LUSTRE_LUSTRE_USER_H
+#    include <linux/lustre/lustre_user.h>
+#  elif defined(HAVE_LUSTRE_LUSTRE_USER_H)
+#    include <lustre/lustre_user.h>
+#  endif
 #endif
 */
 #include "ior.h"
@@ -599,7 +603,7 @@ static void HDFS_Fsync(aiori_fd_t * fd, aiori_mod_opt_t * param) {
 	}
 	if ( hdfsHSync( hdfs_fs, hdfs_file ) != 0 ) {
     // Hsync is implemented to flush out data with newer Hadoop versions
-		EWARN( "hdfsFlush() failed" );
+		WARN( "hdfsFlush() failed" );
 	}
 }
 
@@ -649,7 +653,7 @@ static void HDFS_Delete( char *testFileName, aiori_mod_opt_t * param ) {
 		sprintf(errmsg, "[RANK %03d]: hdfsDelete() of file \"%s\" failed\n",
 		        rank, testFileName);
 
-		EWARN( errmsg );
+		WARN( errmsg );
 	}
 	if (verbose >= VERBOSE_4) {
 		printf("<- HDFS_Delete\n");

--- a/src/aiori-IME.c
+++ b/src/aiori-IME.c
@@ -322,7 +322,7 @@ void IME_Delete(char *testFileName, aiori_mod_opt_t *param)
                 return;
 
         if (ime_native_unlink(testFileName) != 0)
-                EWARNF("[RANK %03d]: cannot delete file \"%s\"\n",
+                WARNF("[RANK %03d]: cannot delete file \"%s\"\n",
                        rank, testFileName);
 }
 

--- a/src/aiori-MMAP.c
+++ b/src/aiori-MMAP.c
@@ -183,7 +183,7 @@ static void MMAP_Fsync(aiori_fd_t *fd, aiori_mod_opt_t * param)
 {
         mmap_options_t *o = (mmap_options_t*) param;
         if (msync(o->mmap_ptr, hints->expectedAggFileSize, MS_SYNC) != 0)
-                EWARN("msync() failed");
+                WARN("msync() failed");
 }
 
 /*

--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -491,7 +491,7 @@ static void MPIIO_Fsync(aiori_fd_t *fdp, aiori_mod_opt_t * module_options)
     return;
   mpiio_fd_t * mfd = (mpiio_fd_t*) fdp;
   if (MPI_File_sync(mfd->fd) != MPI_SUCCESS)
-      EWARN("fsync() failed");
+      WARN("fsync() failed");
 }
 
 /*

--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -32,7 +32,6 @@
  * NCMPI_CHECK will display a custom error message and then exit the program
  */
 #define NCMPI_CHECK(NCMPI_RETURN, MSG) do {                              \
-                                                                         \
     if (NCMPI_RETURN != NC_NOERR) {                                      \
         fprintf(stdout, "** error **\n");                                \
         fprintf(stdout, "ERROR in %s (line %d): %s.\n",                  \
@@ -88,8 +87,8 @@ static option_help * NCMPI_options(aiori_mod_opt_t ** init_backend_options, aior
   *init_backend_options = (aiori_mod_opt_t*) o;
 
   option_help h [] = {
-    {0, "mpiio.hintsFileName","Full name for hints file", OPTION_OPTIONAL_ARGUMENT, 's', & o->hintsFileName},
-    {0, "mpiio.showHints",    "Show MPI hints", OPTION_FLAG, 'd', & o->showHints},
+    {0, "ncmpi.hintsFileName","Full name for hints file", OPTION_OPTIONAL_ARGUMENT, 's', & o->hintsFileName},
+    {0, "ncmpi.showHints",    "Show MPI hints", OPTION_FLAG, 'd', & o->showHints},
     LAST_OPTION
   };
   option_help * help = malloc(sizeof(h));
@@ -153,8 +152,7 @@ static aiori_fd_t *NCMPI_Create(char *testFileName, int iorflags, aiori_mod_opt_
         /* ncmpi_get_file_info is first available in 1.2.0 */
         if (rank == 0 && o->showHints) {
             MPI_Info info_used;
-            MPI_CHECK(ncmpi_get_file_info(*fd, &info_used),
-                      "cannot inquire file info");
+            NCMPI_CHECK(ncmpi_get_file_info(*fd, &info_used), "cannot inquire file info");
             /* print the MPI file hints currently used */
             fprintf(stdout, "\nhints returned from opened file {\n");
             ShowHints(&info_used);

--- a/src/aiori-S3-libs3.c
+++ b/src/aiori-S3-libs3.c
@@ -153,7 +153,7 @@ static void responseCompleteCallback(S3Status status, const S3ErrorDetails *erro
 
 #define CHECK_ERROR(p) \
 if (s3status != S3StatusOK){ \
-  EWARNF("S3 %s:%d (path:%s) \"%s\": %s %s", __FUNCTION__, __LINE__, p,  S3_get_status_name(s3status), s3error.message, s3error.furtherDetails ? s3error.furtherDetails : ""); \
+  WARNF("S3 %s:%d (path:%s) \"%s\": %s %s", __FUNCTION__, __LINE__, p,  S3_get_status_name(s3status), s3error.message, s3error.furtherDetails ? s3error.furtherDetails : ""); \
 }
 
 

--- a/src/aiori-aio.c
+++ b/src/aiori-aio.c
@@ -239,7 +239,6 @@ ior_aiori_t aio_aiori = {
         .initialize = aio_initialize,
         .finalize = aio_finalize,
         .xfer_hints = aio_xfer_hints,
-        .get_options = aio_options,
         .fsync = aio_Fsync,
         .open = aio_Open,
         .xfer = aio_Xfer,

--- a/src/aiori-debug.h
+++ b/src/aiori-debug.h
@@ -6,126 +6,95 @@
 #include <stdio.h>
 #include <mpi.h>
 
+/* output log file */
 extern FILE * out_logfile;
-extern int verbose;                            /* verbose output */
+/* verbosity level */
+extern int verbose;
+/* treat warnings as errors */
+extern int aiori_warning_as_errors;
 
 #define FAIL(...) FailMessage(rank, ERROR_LOCATION, __VA_ARGS__)
 void FailMessage(int rank, const char *location, char *format, ...);
 
-/******************************** M A C R O S *********************************/
-
-/******************************************************************************/
-/*
- * WARN_RESET will display a custom error message and set value to default
- */
-#define WARN_RESET(MSG, TO_STRUCT_PTR, FROM_STRUCT_PTR, MEMBER) do {     \
-        (TO_STRUCT_PTR)->MEMBER = (FROM_STRUCT_PTR)->MEMBER;             \
-        if (rank == 0) {                                                 \
-            fprintf(out_logfile, "WARNING: %s.  Using value of %d.\n",    \
-                    MSG, (TO_STRUCT_PTR)->MEMBER);                       \
-        }                                                                \
-        fflush(out_logfile);                                                  \
+/* display simple warning message and reset member value to default */
+#define WARN_RESET(MSG, TO_STRUCT_PTR, FROM_STRUCT_PTR, MEMBER) do {    \
+    (TO_STRUCT_PTR)->MEMBER = (FROM_STRUCT_PTR)->MEMBER;                \
+    if (rank == 0) {                                                    \
+        fprintf(out_logfile, "WARNING: %s. Using value of %d.\n",       \
+                MSG, (TO_STRUCT_PTR)->MEMBER);                          \
+    }                                                                   \
+    fflush(out_logfile);                                                \
 } while (0)
 
-extern int aiori_warning_as_errors;
-
-#define WARN(MSG) do {                                                   \
-        if(aiori_warning_as_errors){ ERR(MSG); }                           \
-        if (verbose > VERBOSE_2) {                                       \
-            fprintf(out_logfile, "WARNING: %s, (%s:%d).\n",               \
-                    MSG, __FILE__, __LINE__);                            \
-        } else {                                                         \
-            fprintf(out_logfile, "WARNING: %s.\n", MSG);                  \
-        }                                                                \
-        fflush(out_logfile);                                                  \
+/* display warning message with format string */
+#define WARNF(FORMAT, ...) do {                                         \
+    if(aiori_warning_as_errors){                                        \
+        ERRF(FORMAT, __VA_ARGS__);                                      \
+    }                                                                   \
+    if (verbose > VERBOSE_2) {                                          \
+        fprintf(out_logfile, "WARNING: " FORMAT ", (%s:%d).\n",         \
+                __VA_ARGS__,  __FILE__, __LINE__);                      \
+    } else {                                                            \
+        fprintf(out_logfile, "WARNING: " FORMAT "\n",                   \
+                __VA_ARGS__);                                           \
+    }                                                                   \
+    fflush(out_logfile);                                                \
 } while (0)
 
-
-/* warning with format string and errno printed */
-#define EWARNF(FORMAT, ...) do {                                         \
-        if(aiori_warning_as_errors){ ERRF(FORMAT, __VA_ARGS__); }          \
-        if (verbose > VERBOSE_2) {                                       \
-            fprintf(out_logfile, "WARNING: " FORMAT ", (%s:%d).\n", \
-                    __VA_ARGS__,  __FILE__, __LINE__); \
-        } else {                                                         \
-            fprintf(out_logfile, "WARNING: " FORMAT "\n",  \
-                    __VA_ARGS__);                \
-        }                                                                \
-        fflush(out_logfile);                                                  \
+/* display simple warning message */
+#define WARN(MSG) do {                                                  \
+    WARNF("%s", MSG);                                                   \
 } while (0)
 
-
-/* warning with errno printed */
-#define EWARN(MSG) do {                                                  \
-        EWARNF("%s", MSG);                                               \
+/* display info message with format string */
+#define INFOF(FORMAT, ...) do {                                         \
+    if (verbose > VERBOSE_2) {                                          \
+        fprintf(out_logfile, "INFO: " FORMAT ", (%s:%d).\n",            \
+                __VA_ARGS__,  __FILE__, __LINE__);                      \
+    } else {                                                            \
+        fprintf(out_logfile, "INFO: " FORMAT "\n",                      \
+                __VA_ARGS__);                                           \
+    }                                                                   \
+    fflush(out_logfile);                                                \
 } while (0)
 
-
-/* warning with format string and errno printed */
-#define EINFO(FORMAT, ...) do {                                         \
-        if (verbose > VERBOSE_2) {                                       \
-            fprintf(out_logfile, "INFO: " FORMAT ", (%s:%d).\n", \
-                    __VA_ARGS__,  __FILE__, __LINE__); \
-        } else {                                                         \
-            fprintf(out_logfile, "INFO: " FORMAT "\n",  \
-                    __VA_ARGS__);                \
-        }                                                                \
-        fflush(out_logfile);                                                  \
+/* display simple info message */
+#define INFO(MSG) do {                                                  \
+    INFOF("%s", MSG);                                                   \
 } while (0)
 
 /* display error message with format string and terminate execution */
-#define ERRF(FORMAT, ...) do {                                           \
-        fprintf(out_logfile, "ERROR: " FORMAT ", (%s:%d)\n", \
-                __VA_ARGS__, __FILE__, __LINE__); \
-        fflush(out_logfile);                                                  \
-        MPI_Abort(MPI_COMM_WORLD, -1);                                   \
+#define ERRF(FORMAT, ...) do {                                          \
+    fprintf(out_logfile, "ERROR: " FORMAT ", (%s:%d)\n",                \
+            __VA_ARGS__, __FILE__, __LINE__);                           \
+    fflush(out_logfile);                                                \
+    MPI_Abort(MPI_COMM_WORLD, -1);                                      \
 } while (0)
 
-
-/* display error message and terminate execution */
-#define ERR_ERRNO(MSG) do {                                                    \
-        ERRF("%s", MSG);                                                 \
+/* display simple error message and terminate execution */
+#define ERR(MSG) do {                                                   \
+    ERRF("%s", MSG);                                                    \
 } while (0)
 
-
-/* display a simple error message (i.e. errno is not set) and terminate execution */
-#define ERR(MSG) do {                                            \
-        fprintf(out_logfile, "ERROR: %s, (%s:%d)\n",                     \
-                MSG, __FILE__, __LINE__);                               \
-        fflush(out_logfile);                                                 \
+/* if MPI_STATUS indicates error, display error message with format
+/* string and error string from MPI_STATUS and terminate execution */
+#define MPI_CHECKF(MPI_STATUS, FORMAT, ...) do {                        \
+    char resultString[MPI_MAX_ERROR_STRING];                            \
+    int resultLength;                                                   \
+                                                                        \
+    if (MPI_STATUS != MPI_SUCCESS) {                                    \
+        MPI_Error_string(MPI_STATUS, resultString, &resultLength);      \
+        fprintf(out_logfile, "ERROR: " FORMAT ", MPI %s, (%s:%d)\n",    \
+                __VA_ARGS__, resultString, __FILE__, __LINE__);         \
+        fflush(out_logfile);                                            \
         MPI_Abort(MPI_COMM_WORLD, -1);                                  \
-} while (0)
-
-
-/******************************************************************************/
-/*
- * MPI_CHECKF will display a custom format string as well as an error string
- * from the MPI_STATUS and then exit the program
- */
-
-#define MPI_CHECKF(MPI_STATUS, FORMAT, ...) do {                         \
-    char resultString[MPI_MAX_ERROR_STRING];                             \
-    int resultLength;                                                    \
-    int checkf_mpi_status = MPI_STATUS;                                  \
-                                                                         \
-    if (checkf_mpi_status != MPI_SUCCESS) {                              \
-        MPI_Error_string(checkf_mpi_status, resultString, &resultLength);\
-        fprintf(out_logfile, "ERROR: " FORMAT ", MPI %s, (%s:%d)\n",     \
-                __VA_ARGS__, resultString, __FILE__, __LINE__);          \
-        fflush(out_logfile);                                             \
-        MPI_Abort(MPI_COMM_WORLD, -1);                                   \
-    }                                                                    \
+    }                                                                   \
 } while(0)
 
-
-/******************************************************************************/
-/*
- * MPI_CHECK will display a custom error message as well as an error string
- * from the MPI_STATUS and then exit the program
- */
-
-#define MPI_CHECK(MPI_STATUS, MSG) do {                                  \
-    MPI_CHECKF(MPI_STATUS, "%s", MSG);                                   \
+/* if MPI_STATUS indicates error, display simple error message with */
+/* error string from MPI_STATUS and terminate execution */
+#define MPI_CHECK(MPI_STATUS, MSG) do {                                 \
+    MPI_CHECKF(MPI_STATUS, "%s", MSG);                                  \
 } while(0)
 
 #endif

--- a/src/ior-output.c
+++ b/src/ior-output.c
@@ -297,7 +297,7 @@ void PrintHeader(int argc, char **argv)
         }
         PrintKeyValEnd();
         if (uname(&unamebuf) != 0) {
-                EWARN("uname failed");
+                WARN("uname failed");
                 PrintKeyVal("Machine", "Unknown");
         } else {
                 PrintKeyValStart("Machine");

--- a/src/ior.c
+++ b/src/ior.c
@@ -120,7 +120,7 @@ static int test_initialize(IOR_test_t * test){
 #ifdef HAVE_CUDA
   cudaError_t cret = cudaSetDevice(test->params.gpuID);
   if(cret != cudaSuccess){
-    EWARNF("cudaSetDevice(%d) error: %s", test->params.gpuID, cudaGetErrorString(cret));
+    WARNF("cudaSetDevice(%d) error: %s", test->params.gpuID, cudaGetErrorString(cret));
   }
 #endif
 
@@ -314,7 +314,7 @@ DisplayOutliers(int numTasks,
                 if (ret != 0)
                         strcpy(hostname, "unknown");
 
-                EWARNF("for %s, task %d, %s %s is %f (mean=%f, stddev=%f)\n",
+                WARNF("for %s, task %d, %s %s is %f (mean=%f, stddev=%f)\n",
                         hostname, rank, accessString, timeString, timerVal,  mean, sd);
         }
 }
@@ -388,11 +388,11 @@ static void CheckFileSize(IOR_test_t *test, char * testFilename, IOR_offset_t da
                              != point->aggFileSizeFromXfer)
                             || (point->aggFileSizeFromStat
                                 != point->aggFileSizeFromXfer)) {
-                                EWARNF("Expected aggregate file size       = %lld", (long long) params->expectedAggFileSize);
-                                EWARNF("Stat() of aggregate file size      = %lld", (long long) point->aggFileSizeFromStat);
-                                EWARNF("Using actual aggregate bytes moved = %lld", (long long) point->aggFileSizeFromXfer);
+                                WARNF("Expected aggregate file size       = %lld", (long long) params->expectedAggFileSize);
+                                WARNF("Stat() of aggregate file size      = %lld", (long long) point->aggFileSizeFromStat);
+                                WARNF("Using actual aggregate bytes moved = %lld", (long long) point->aggFileSizeFromXfer);
                                 if(params->deadlineForStonewalling){
-                                  EWARN("Maybe caused by deadlineForStonewalling");
+                                  WARN("Maybe caused by deadlineForStonewalling");
                                 }
                         }
                 }
@@ -433,7 +433,7 @@ static int CountErrors(IOR_param_t * test, int access, int errors)
                                 WARN("overflow in errors counted");
                                 allErrors = -1;
                         }
-                        EWARNF("Incorrect data on %s (%d errors found).\n",
+                        WARNF("Incorrect data on %s (%d errors found).\n",
                                 access == WRITECHECK ? "write" : "read", allErrors);
                         fprintf(out_logfile,
                                 "Used Time Stamp %u (0x%x) for Data Signature\n",
@@ -546,7 +546,7 @@ char * GetPlatformName()
         struct utsname name;
 
         if (uname(&name) != 0) {
-                EWARN("cannot get platform name");
+                WARN("cannot get platform name");
                 sprintf(sysName, "%s", "Unknown");
                 sprintf(nodeName, "%s", "Unknown");
         } else {
@@ -870,9 +870,9 @@ static void InitTests(IOR_test_t *tests)
                         params->numTasks = mpiNumTasks;
                 } else if (params->numTasks > mpiNumTasks) {
                         if (rank == 0) {
-                                EWARNF("More tasks requested (%d) than available (%d),",
+                                WARNF("More tasks requested (%d) than available (%d),",
                                         params->numTasks, mpiNumTasks);
-                                EWARNF("         running with %d tasks.\n", mpiNumTasks);
+                                WARNF("         running with %d tasks.\n", mpiNumTasks);
                         }
                         params->numTasks = mpiNumTasks;
                 }
@@ -1189,7 +1189,7 @@ static void TestIoSys(IOR_test_t *test)
           GetTestFileName(testFileName, params);
           int ret = backend->stat(testFileName, & sb, params->backend_options);
           if(ret == 0) {
-            EWARNF("The file \"%s\" exists already and will be overwritten", testFileName);
+            WARNF("The file \"%s\" exists already and will be overwritten", testFileName);
           }
         }
 

--- a/src/md-workbench.c
+++ b/src/md-workbench.c
@@ -663,7 +663,7 @@ void run_benchmark(phase_stat_t * s, int * current_index_p){
         }
       }else{
         s->obj_read.err++;
-        EWARNF("%d: Error while reading the obj: %s", o.rank, obj_name);
+        WARNF("%d: Error while reading the obj: %s", o.rank, obj_name);
       }
       o.backend->close(aiori_fh, o.backend_options);
 
@@ -710,7 +710,7 @@ void run_benchmark(phase_stat_t * s, int * current_index_p){
         if (! o.ignore_precreate_errors){
          ERRF("%d: Error while creating the obj: %s", o.rank, obj_name);
         }
-        EWARNF("Unable to open file %s", obj_name);
+        WARNF("Unable to open file %s", obj_name);
         s->obj_create.err++;
       }
       bench_runtime = add_timed_result(op_timer, s->phase_start_timer, s->time_create, pos, & s->max_op_time, & op_time);
@@ -986,7 +986,7 @@ mdworkbench_results_t* md_workbench_run(int argc, char ** argv, MPI_Comm world_c
   if (o.phase_precreate){
     if (o.rank == 0){
       if (o.backend->mkdir(o.prefix, DIRMODE, o.backend_options) != 0) {
-          EWARNF("Unable to create test directory %s", o.prefix);
+          WARNF("Unable to create test directory %s", o.prefix);
       }
     }
     init_stats(& phase_stats, o.precreate * o.dset_count);

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -328,11 +328,11 @@ static void create_remove_dirs (const char *path, bool create, uint64_t itemNum)
 
     if (create) {
         if (o.backend->mkdir(curr_item, DIRMODE, o.backend_options) == -1) {
-            EWARNF("unable to create directory %s", curr_item);
+            WARNF("unable to create directory %s", curr_item);
         }
     } else {
         if (o.backend->rmdir(curr_item, o.backend_options) == -1) {
-            EWARNF("unable to remove directory %s", curr_item);
+            WARNF("unable to remove directory %s", curr_item);
         }
     }
 }
@@ -371,7 +371,7 @@ static void create_file (const char *path, uint64_t itemNum) {
 
         ret = o.backend->mknod (curr_item);
         if (ret != 0)
-            EWARNF("unable to mknode file %s", curr_item);
+            WARNF("unable to mknode file %s", curr_item);
 
         return;
     } else if (o.collective_creates) {
@@ -379,7 +379,7 @@ static void create_file (const char *path, uint64_t itemNum) {
 
         aiori_fh = o.backend->open (curr_item, IOR_WRONLY | IOR_CREAT, o.backend_options);
         if (NULL == aiori_fh){
-            EWARNF("unable to open file %s", curr_item);
+            WARNF("unable to open file %s", curr_item);
             return;
         }
 
@@ -392,7 +392,7 @@ static void create_file (const char *path, uint64_t itemNum) {
 
         aiori_fh = o.backend->create (curr_item, IOR_WRONLY | IOR_CREAT, o.backend_options);
         if (NULL == aiori_fh){
-          EWARNF("unable to create file %s", curr_item);
+          WARNF("unable to create file %s", curr_item);
           return;
         }
     }
@@ -404,13 +404,13 @@ static void create_file (const char *path, uint64_t itemNum) {
         update_write_memory_pattern(itemNum, o.write_buffer, o.write_bytes, o.random_buffer_offset, rank, o.dataPacketType);
 
         if ( o.write_bytes != (size_t) o.backend->xfer(WRITE, aiori_fh, (IOR_size_t *) o.write_buffer, o.write_bytes, 0, o.backend_options)) {
-            EWARNF("unable to write file %s", curr_item);
+            WARNF("unable to write file %s", curr_item);
         }
 
         if (o.verify_write) {
             o.write_buffer[0] = 42;
             if (o.write_bytes != (size_t) o.backend->xfer(READ, aiori_fh, (IOR_size_t *) o.write_buffer, o.write_bytes, 0, o.backend_options)) {
-                EWARNF("unable to verify write (read/back) file %s", curr_item);
+                WARNF("unable to verify write (read/back) file %s", curr_item);
             }
             int error = verify_memory_pattern(itemNum, o.write_buffer, o.write_bytes, o.random_buffer_offset, rank, o.dataPacketType);
             o.verification_error += error;
@@ -470,7 +470,7 @@ void collective_helper(const int dirs, const int create, const char* path, uint6
             //create files
             aiori_fh = o.backend->create (curr_item, IOR_WRONLY | IOR_CREAT, o.backend_options);
             if (NULL == aiori_fh) {
-                EWARNF("unable to create file %s", curr_item);
+                WARNF("unable to create file %s", curr_item);
             }else{
               o.backend->close (aiori_fh, o.backend_options);
             }
@@ -634,7 +634,7 @@ void mdtest_stat(const int random, const int dirs, const long dir_iter, const ch
         /* below temp used to be hiername */
         VERBOSE(3,5,"mdtest_stat %4s: %s", (dirs ? "dir" : "file"), item);
         if (-1 == o.backend->stat (item, &buf, o.backend_options)) {
-            EWARNF("unable to stat %s %s", dirs ? "directory" : "file", item);
+            WARNF("unable to stat %s %s", dirs ? "directory" : "file", item);
         }
     }
 }
@@ -724,7 +724,7 @@ void mdtest_read(int random, int dirs, const long dir_iter, char *path) {
         /* open file for reading */
         aiori_fh = o.backend->open (item, O_RDONLY, o.backend_options);
         if (NULL == aiori_fh) {
-            EWARNF("unable to open file %s", item);
+            WARNF("unable to open file %s", item);
             continue;
         }
 
@@ -732,7 +732,7 @@ void mdtest_read(int random, int dirs, const long dir_iter, char *path) {
         if (o.read_bytes > 0) {
             read_buffer[0] = 42;
             if (o.read_bytes != (size_t) o.backend->xfer(READ, aiori_fh, (IOR_size_t *) read_buffer, o.read_bytes, 0, o.backend_options)) {
-                EWARNF("unable to read file %s", item);
+                WARNF("unable to read file %s", item);
                 continue;
             }
             int pretend_rank = (2 * o.nstride + rank) % o.size;
@@ -900,7 +900,7 @@ void rename_dir_test(const int dirs, const long dir_iter, const char *path, rank
           strcpy(item, first_item_name);
         }
         if (-1 == o.backend->rename(item, item_last, o.backend_options)) {
-            EWARNF("unable to rename %s %s", dirs ? "directory" : "file", item);
+            WARNF("unable to rename %s %s", dirs ? "directory" : "file", item);
         }
 
         strcpy(item_last, item);
@@ -1888,7 +1888,7 @@ void create_remove_directory_tree(int create,
         if (create) {
             VERBOSE(2,5,"Making directory '%s'", dir);
             if (-1 == o.backend->mkdir (dir, DIRMODE, o.backend_options)) {
-                EWARNF("unable to create tree directory '%s'", dir);
+                WARNF("unable to create tree directory '%s'", dir);
             }
 #ifdef HAVE_LUSTRE_LUSTREAPI
             /* internal node for branching, can be non-striped for children */
@@ -1906,7 +1906,7 @@ void create_remove_directory_tree(int create,
         if (!create) {
             VERBOSE(2,5,"Remove directory '%s'", dir);
             if (-1 == o.backend->rmdir(dir, o.backend_options)) {
-                EWARNF("Unable to remove directory %s", dir);
+                WARNF("Unable to remove directory %s", dir);
             }
         }
     } else if (currDepth <= o.depth) {
@@ -1922,7 +1922,7 @@ void create_remove_directory_tree(int create,
             if (create) {
                 VERBOSE(2,5,"Making directory '%s'", temp_path);
                 if (-1 == o.backend->mkdir(temp_path, DIRMODE, o.backend_options)) {
-                    EWARNF("Unable to create directory %s", temp_path);
+                    WARNF("Unable to create directory %s", temp_path);
                 }
             }
 
@@ -1933,7 +1933,7 @@ void create_remove_directory_tree(int create,
             if (!create) {
                 VERBOSE(2,5,"Remove directory '%s'", temp_path);
                 if (-1 == o.backend->rmdir(temp_path, o.backend_options)) {
-                    EWARNF("Unable to remove directory %s", temp_path);
+                    WARNF("Unable to remove directory %s", temp_path);
                 }
             }
 
@@ -1966,12 +1966,12 @@ static void mdtest_iteration(int i, int j, mdtest_results_t * summary_table){
       VERBOSE(2,5,"main (for j loop): making o.testdir, '%s'", o.testdir );
       if (o.backend->access(o.testdir, F_OK, o.backend_options) != 0) {
           if (o.backend->mkdir(o.testdir, DIRMODE, o.backend_options) != 0) {
-              EWARNF("Unable to create test directory %s", o.testdir);
+              WARNF("Unable to create test directory %s", o.testdir);
           }
 #ifdef HAVE_LUSTRE_LUSTREAPI
           /* internal node for branching, can be non-striped for children */
           if (o.global_dir_layout && o.unique_dir_per_task && llapi_dir_set_default_lmv_stripe(o.testdir, -1, 0, LMV_HASH_TYPE_FNV_1A_64, NULL) == -1) {
-              EWARNF("Unable to reset to global default directory layout", 0);
+              WARN("Unable to reset to global default directory layout");
           }
 #endif /* HAVE_LUSTRE_LUSTREAPI */
       }
@@ -2148,7 +2148,7 @@ static void mdtest_iteration(int i, int j, mdtest_results_t * summary_table){
         if ((rank < o.path_count) && o.backend->access(o.testdir, F_OK, o.backend_options) == 0) {
             //if (( rank == 0 ) && access(o.testdir, F_OK) == 0) {
             if (o.backend->rmdir(o.testdir, o.backend_options) == -1) {
-                EWARNF("unable to remove directory %s", o.testdir);
+                WARNF("unable to remove directory %s", o.testdir);
             }
         }
       }
@@ -2458,7 +2458,7 @@ mdtest_results_t * mdtest_run(int argc, char **argv, MPI_Comm world_com, FILE * 
     /*   if directory does not exist, create it */
     if ((rank < o.path_count) && o.backend->access(o.testdirpath, F_OK, o.backend_options) != 0) {
         if (o.backend->mkdir(o.testdirpath, DIRMODE, o.backend_options) != 0) {
-            EWARNF("Unable to create test directory path %s", o.testdirpath);
+            WARNF("Unable to create test directory path %s", o.testdirpath);
         }
         created_root_dir = 1;
     }

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -457,7 +457,7 @@ option_help * createGlobalOptions(IOR_param_t * params){
     {'M', NULL,        "memoryPerNode -- hog memory on the node  (e.g.: 2g, 75%)", OPTION_OPTIONAL_ARGUMENT, 's', & params->memoryPerNodeStr},
     {'N', NULL,        "numTasks -- number of tasks that are participating in the test (overrides MPI)", OPTION_OPTIONAL_ARGUMENT, 'd', & params->numTasks},
     {'o', NULL,        "testFile -- full name for test", OPTION_OPTIONAL_ARGUMENT, 's', & params->testFileName},
-    {'O', NULL,        "string of IOR directives (e.g. -O checkRead=1,lustreStripeCount=32)", OPTION_OPTIONAL_ARGUMENT, 'p', & decodeDirectiveWrapper},
+    {'O', NULL,        "string of IOR directives (e.g. -O checkRead=1,GPUid=2)", OPTION_OPTIONAL_ARGUMENT, 'p', & decodeDirectiveWrapper},
     {'Q', NULL,        "taskPerNodeOffset for read tests use with -C & -Z options (-C constant N, -Z at least N)", OPTION_OPTIONAL_ARGUMENT, 'd', & params->taskPerNodeOffset},
     {'r', NULL,        "readFile -- read existing file", OPTION_FLAG, 'd', & params->readFile},
     {'R', NULL,        "checkRead -- verify that the output of read matches the expected signature (used with -G)", OPTION_FLAG, 'd', & params->checkRead},


### PR DESCRIPTION
Hi everyone,

Looking to contribute some improvements to IOR which cover:
- Updated documentation to include some of the newer options in or near the information which I newly added for Lustre
- Improved the HDF5 backend so it is able to flush files to disk (`-e` option) and print file hints (`--hdf5.showHints` option); a controversial change might be the removal of version macro checks for old HDF5 version (10+ years)
- Unify naming and usage of debug macros (`WARN`, `INFO`, `ERR`, and associated ones) across all files in the repository which did not only eliminate some compiler warnings but should have fixed some bugs in format strings
- Rename `mpiio.*` options in NCMPI backend to `ncmpi.*`
- Replace `MPI_CHECK` with `NCMPI_CHECK` where appropriate
- Remove duplicate `.get_options = aio_options`
- Extract function `void lustre_disable_file_locks(int fd)` for disabling lustre locking on a file
- Minor code formatting improvements

Hope to provide some worthwhile changes to improve code and documentation quality of this awesome benchmark.

Best,

Christian
