### PR TITLE
Fixes missing termination of multi-line comment

### DIFF
--- a/src/aiori-debug.h
+++ b/src/aiori-debug.h
@@ -76,7 +76,7 @@ void FailMessage(int rank, const char *location, char *format, ...);
     ERRF("%s", MSG);                                                    \
 } while (0)
 
-/* if MPI_STATUS indicates error, display error message with format
+/* if MPI_STATUS indicates error, display error message with format */
 /* string and error string from MPI_STATUS and terminate execution */
 #define MPI_CHECKF(MPI_STATUS, FORMAT, ...) do {                        \
     char resultString[MPI_MAX_ERROR_STRING];                            \


### PR DESCRIPTION
Hi again,

In a comment to the last merge commit cbedd6afddb241790a0fdc126ea8d205d9bb3cf7 it was noted that one of the previous changes introduced an unbalanced multi-line comment due to a missing `*/` at the end of a line. This pull request just fixes this issue.

I am sorry that a second pull request is required to fix the prior introduced issue. Guess that shows you can never have enough compilers to test an implementation against 😃

Best,

Christian
