### PR TITLE
aiori/DFS: fix an issue when destorying a container

### DIFF
--- a/src/aiori-DFS.c
+++ b/src/aiori-DFS.c
@@ -633,11 +633,14 @@ DFS_Finalize(aiori_mod_opt_t *options)
 
 	if (o->destroy) {
                 if (rank == 0) {
-                        uuid_t uuid;
-
                         INFO(VERBOSE_1, "Destroying DFS Container: %s", o->cont);
+#if CHECK_DAOS_API_VERSION(1, 4)
+                        daos_cont_destroy(poh, o->cont, 1, NULL);
+#else
+                        uuid_t uuid;
                         uuid_parse(o->cont, uuid);
                         rc = daos_cont_destroy(poh, uuid, 1, NULL);
+#endif
                         DCHECK(rc, "Failed to destroy container %s", o->cont);
                 }
 


### PR DESCRIPTION
When using the new API with container labels, use the label to destory
the container as that doesn't have to be a uuid.