### PR TITLE
Fix #410.

### DIFF
--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -48,15 +48,16 @@
 #if H5_VERS_MAJOR > 1 && H5_VERS_MINOR > 6
 #define HDF5_CHECK(HDF5_RETURN, MSG) do {                                \
     char   resultString[1024];                                           \
+    herr_t _HDF5_RETURN = (HDF5_RETURN);                                 \
                                                                          \
-    if (HDF5_RETURN < 0) {                                               \
+    if (_HDF5_RETURN < 0) {                                              \
         fprintf(stdout, "** error **\n");                                \
         fprintf(stdout, "ERROR in %s (line %d): %s.\n",                  \
                 __FILE__, __LINE__, MSG);                                \
-        strcpy(resultString, H5Eget_major((H5E_major_t)HDF5_RETURN));    \
+        strcpy(resultString, H5Eget_major((H5E_major_t)_HDF5_RETURN));   \
         if (strcmp(resultString, "Invalid major error number") != 0)     \
             fprintf(stdout, "HDF5 %s\n", resultString);                  \
-        strcpy(resultString, H5Eget_minor((H5E_minor_t)HDF5_RETURN));    \
+        strcpy(resultString, H5Eget_minor((H5E_minor_t)_HDF5_RETURN));   \
         if (strcmp(resultString, "Invalid minor error number") != 0)     \
             fprintf(stdout, "%s\n", resultString);                       \
         fprintf(stdout, "** exiting **\n");                              \

--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -32,11 +32,13 @@
  * NCMPI_CHECK will display a custom error message and then exit the program
  */
 #define NCMPI_CHECK(NCMPI_RETURN, MSG) do {                              \
-    if (NCMPI_RETURN != NC_NOERR) {                                      \
+    int _NCMPI_RETURN = (NCMPI_RETURN);                                  \
+                                                                         \
+    if (_NCMPI_RETURN != NC_NOERR) {                                     \
         fprintf(stdout, "** error **\n");                                \
         fprintf(stdout, "ERROR in %s (line %d): %s.\n",                  \
                 __FILE__, __LINE__, MSG);                                \
-        fprintf(stdout, "ERROR: %s.\n", ncmpi_strerror(NCMPI_RETURN));   \
+        fprintf(stdout, "ERROR: %s.\n", ncmpi_strerror(_NCMPI_RETURN));  \
         fprintf(stdout, "** exiting **\n");                              \
         exit(EXIT_FAILURE);                                              \
     }                                                                    \

--- a/src/aiori-debug.h
+++ b/src/aiori-debug.h
@@ -81,9 +81,10 @@ void FailMessage(int rank, const char *location, char *format, ...);
 #define MPI_CHECKF(MPI_STATUS, FORMAT, ...) do {                        \
     char resultString[MPI_MAX_ERROR_STRING];                            \
     int resultLength;                                                   \
+    int _MPI_STATUS = (MPI_STATUS);                                     \
                                                                         \
-    if (MPI_STATUS != MPI_SUCCESS) {                                    \
-        MPI_Error_string(MPI_STATUS, resultString, &resultLength);      \
+    if (_MPI_STATUS != MPI_SUCCESS) {                                   \
+        MPI_Error_string(_MPI_STATUS, resultString, &resultLength);     \
         fprintf(out_logfile, "ERROR: " FORMAT ", MPI %s, (%s:%d)\n",    \
                 __VA_ARGS__, resultString, __FILE__, __LINE__);         \
         fflush(out_logfile);                                            \


### PR DESCRIPTION
Added a local variable to the affected macros which ensures the
parameter is expanded first to prevent multiple calls to any embedded
functions.