### PR TITLE
mdtest: fix barrier option

### DIFF
--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -270,9 +270,9 @@ static void phase_prepare(){
   if (*o.prologue){
     VERBOSE(0,5,"calling prologue: \"%s\"", o.prologue);
     system(o.prologue);
-    if (o.barriers) {
-      MPI_Barrier(testComm);
-    }
+  }
+  if (o.barriers) {
+    MPI_Barrier(testComm);
   }
 }
 


### PR DESCRIPTION
Barrier option should be on by default; however currently it's not called
since the barrier is in a prologue check.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>