### PR TITLE
Add option to link IOR to Darshan

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,21 @@ AM_COND_IF([WITH_LUSTRE],[
         AC_DEFINE([WITH_LUSTRE], [], [Build wth LUSTRE backend])
 ])
 
+# enable darshan profiling support
+AC_ARG_ENABLE(darshan,
+              AS_HELP_STRING([--enable-darshan], [Build with Darshan I/O profiler]),
+              [],
+              [enable_darshan=no])
+AS_IF([test "x$enable_darshan" != "xno"],[
+    AS_IF([test -d "$enable_darshan"],
+        [],
+        AC_MSG_ERROR(enableval for enable-darshan is required and must be a valid install prefix path for Darshan library)
+    )
+    LDFLAGS="$LDFLAGS -L${enable_darshan}/lib -Wl,-rpath=${enable_darshan}/lib -Wl,-no-as-needed"
+	AC_CHECK_LIB([darshan], [darshan_core_initialize], [],
+                   [AC_MSG_ERROR([Cannot find Darshan])])
+])
+
 # IME (DDN's Infinite Memory Engine) support
 AC_ARG_WITH([ime],
         [AS_HELP_STRING([--with-ime],


### PR DESCRIPTION
This PR adds an option to the config script to build IOR with Darshan. The user can use `--enable-darshan` and provide an installation prefix to their Darshan shared library. The script modifies `LDFLAGS` to add the necessary flags and checks if the library exists.

IOR allows a very flexible micro benchmarking with different parameters. Together with Darshan, this can provide a very useful analysis with fine-grained I/O traces to explain performance. I am currently developing an I/O library and using IOR to quantify the performance characteristics. However, it is not possible to `LD_PRELOAD` the same functions twice, for this reason, a Darshan enabled IOR proves extremely useful to my current work and can benefit developers in similar situations.