### PR TITLE
IOR: allow minimum runtime. Compatible with stonewall

### DIFF
--- a/src/ior.h
+++ b/src/ior.h
@@ -133,6 +133,7 @@ typedef struct
     int useExistingTestFile;         /* do not delete test file before access */
     int deadlineForStonewalling;     /* max time in seconds to run any test phase */
     int stoneWallingWearOut;         /* wear out the stonewalling, once the timeout is over, each process has to write the same amount */
+    int minTimeDuration;             /* minimum runtime */
     uint64_t stoneWallingWearOutIterations; /* the number of iterations for the stonewallingWearOut, needed for readBack */
     char * stoneWallingStatusFile;
 

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -164,6 +164,8 @@ void DecodeDirective(char *line, IOR_param_t *params, options_all_t * module_opt
                 params->stoneWallingStatusFile  = strdup(value);
         } else if (strcasecmp(option, "maxtimeduration") == 0) {
                 params->maxTimeDuration = atoi(value);
+        } else if (strcasecmp(option, "mintimeduration") == 0) {
+                params->minTimeDuration = atoi(value);
         } else if (strcasecmp(option, "outlierthreshold") == 0) {
                 params->outlierThreshold = atoi(value);
         } else if (strcasecmp(option, "numnodes") == 0) {
@@ -431,6 +433,7 @@ option_help * createGlobalOptions(IOR_param_t * params){
     {.help="  -O stoneWallingWearOut=1           -- once the stonewalling timeout is over, all process finish to access the amount of data", .arg = OPTION_OPTIONAL_ARGUMENT},
     {.help="  -O stoneWallingWearOutIterations=N -- stop after processing this number of iterations, needed for reading data back written with stoneWallingWearOut", .arg = OPTION_OPTIONAL_ARGUMENT},
     {.help="  -O stoneWallingStatusFile=FILE     -- this file keeps the number of iterations from stonewalling during write and allows to use them for read", .arg = OPTION_OPTIONAL_ARGUMENT},
+    {.help="  -O minTimeDuration=0           -- minimum Runtime for the run (will repeat from beginning of the file if time is not yet over)", .arg = OPTION_OPTIONAL_ARGUMENT},
 #ifdef HAVE_CUDA
     {.help="  -O allocateBufferOnGPU=X           -- allocate I/O buffers on the GPU: X=1 uses managed memory, X=2 device memory.", .arg = OPTION_OPTIONAL_ARGUMENT},
     {.help="  -O GPUid=X                         -- select the GPU to use.", .arg = OPTION_OPTIONAL_ARGUMENT},


### PR DESCRIPTION
Allow running IOR with a minimum runtime by repeating the current pattern from the beginning of the file. That means in a write that didn't complete until a certain deadline, the file will be over-written from the beginning.

Especially useful when you want to enforce a runtime for (random) reads.

Example usage:
$ mpiexec -np 4 ./src/ior -O minTimeDuration=1 -D=2 -O stoneWallingWearOut=1 -k
