### PR TITLE
aiori-POSIX: Spectrum Scale finegrainreadsharing performance updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,7 @@ AS_IF([test "$ac_cv_header_gpfs_h" = "yes" -o "$ac_cv_header_gpfs_fcntl_h" = "ye
         [AC_MSG_ERROR([Library containing gpfs_fcntl symbols not found])
         ])
         AC_CHECK_TYPES([gpfsFineGrainWriteSharing_t], [], [], [[#include <gpfs_fcntl.h>]])
+        AC_CHECK_TYPES([gpfsFineGrainReadSharing_t], [], [], [[#include <gpfs_fcntl.h>]])
     ])
 ])
 

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -322,7 +322,11 @@ void gpfs_fineGrainReadSharing(int fd)
         struct
         {
                 gpfsFcntlHeader_t header;
+#ifdef HAVE_GPFSFINEGRAINREADSHARING_T
+                gpfsFineGrainReadSharing_t read;
+#else
                 gpfsPrefetch_t read;
+#endif
         } sharingHint;
         int rc;
 
@@ -331,9 +335,14 @@ void gpfs_fineGrainReadSharing(int fd)
         sharingHint.header.fcntlReserved = 0;
 
         sharingHint.read.structLen = sizeof(sharingHint.read);
+#ifdef HAVE_GPFSFINEGRAINREADSHARING_T
+        sharingHint.read.structType = GPFS_FINE_GRAIN_READ_SHARING;
+        sharingHint.read.fineGrainReadSharing = 1;
+#else
         sharingHint.read.structType = GPFS_PREFETCH;
         sharingHint.read.prefetchEnableRead = 0;
         sharingHint.read.prefetchEnableWrite = 1;
+#endif
 
         rc = gpfs_fcntl(fd, &sharingHint);
         if (verbose >= VERBOSE_2 && rc != 0) {


### PR DESCRIPTION
Update --posix.gpfs.finegrainreadsharing hint with latest optimizations
in IBM Spectrum Scale - 5.1.4 for small strided reads from a shared
file in a parallel application.

Fixes https://github.com/hpc/ior/issues/418

Signed-off-by: Pidad D'Souza <pidsouza@in.ibm.com>