### PR TITLE
HDF5 Backend - fix dry run return fall-through in HDF5_Delete

### DIFF
--- a/src/aiori-HDF5.c
+++ b/src/aiori-HDF5.c
@@ -502,7 +502,7 @@ static void HDF5_Close(aiori_fd_t *afd, aiori_mod_opt_t * param)
 static void HDF5_Delete(char *testFileName, aiori_mod_opt_t * param)
 {
   if(hints->dryRun)
-    return
+    return;
   MPIIO_Delete(testFileName, param);
   return;
 }


### PR DESCRIPTION
This is currently innocuous since MPIIO_Delete returns early on dry runs, but might be a problem if something changes in the future.