### PR TITLE
mdtest: Add new IBM Spectrum Scale createsharing hint

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,7 @@ AS_IF([test "$ac_cv_header_gpfs_h" = "yes" -o "$ac_cv_header_gpfs_fcntl_h" = "ye
         ])
         AC_CHECK_TYPES([gpfsFineGrainWriteSharing_t], [], [], [[#include <gpfs_fcntl.h>]])
         AC_CHECK_TYPES([gpfsFineGrainReadSharing_t], [], [], [[#include <gpfs_fcntl.h>]])
+        AC_CHECK_TYPES([gpfsCreateSharing_t], [], [], [[#include <gpfs_fcntl.h>]])
     ])
 ])
 

--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -381,13 +381,16 @@ GPFS-SPECIFIC (POSIX-ONLY):
 
   * --posix.gpfs.releasetoken             - immediately after opening or creating file, release
                                             all locks.  Might help mitigate lock-revocation
-                                            traffic when many processes write/read to same file.
+                                            traffic when many processes write/read to same file
 
   * --posix.gpfs.finegrainwritesharing    - This hint optimizes the performance of small strided
                                             writes to a shared file from a parallel application
 
   * --posix.gpfs.finegrainreadsharing     - This hint optimizes the performance of small strided
                                             reads from a shared file from a parallel application
+
+  * --posix.gpfs.createsharing            - This hint optimizes the performance of workloads that
+                                            create many files in a shared directory
 
 BeeGFS-SPECIFIC (POSIX-ONLY):
 ================

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -142,8 +142,10 @@ option_help * POSIX_options(aiori_mod_opt_t ** init_backend_options, aiori_mod_o
     {0, "posix.gpfs.finegrainwritesharing", "    Enable fine grain write sharing", OPTION_FLAG, 'd', & o->gpfs_finegrain_writesharing},
     {0, "posix.gpfs.finegrainreadsharing", "     Enable fine grain read sharing", OPTION_FLAG, 'd', & o->gpfs_finegrain_readsharing},
 #endif
-
+#ifdef HAVE_GPFSCREATESHARING_T
+    {0, "posix.gpfs.createsharing", "        Enable efficient file creation in a shared directory", OPTION_FLAG, 'd', & o->gpfs_createsharing},
 #endif
+#endif // HAVE_GPFS_FCNTL_H
 #ifdef HAVE_LUSTRE_USER
     {0, "posix.lustre.stripecount", "", OPTION_OPTIONAL_ARGUMENT, 'd', & o->lustre_stripe_count},
     {0, "posix.lustre.stripesize", "", OPTION_OPTIONAL_ARGUMENT, 'd', & o->lustre_stripe_size},

--- a/src/aiori-POSIX.h
+++ b/src/aiori-POSIX.h
@@ -21,6 +21,8 @@ typedef struct{
                                     creating or opening a file */
   int gpfs_finegrain_writesharing;  /* Enable fine grain write sharing */
   int gpfs_finegrain_readsharing;   /* Enable fine grain read sharing */
+  int gpfs_createsharing;        /* Enable efficient file creation in
+                                    a shared directory */
 
   /* beegfs variables */
   int beegfs_numTargets;           /* number storage targets to use */


### PR DESCRIPTION
Add below option to mdtest to optimize performance on IBM Spectrum Scale version later than 5.1.5.
createsharing : This hint optimizes the performance of workloads that
                           create many files in a shared directory

Fixes https://github.com/hpc/ior/issues/435

Signed-off-by: Pidad D'Souza <pidsouza@in.ibm.com>