### PR TITLE
RADOS backend fixes/updates

### DIFF
--- a/src/aiori-RADOS.c
+++ b/src/aiori-RADOS.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <errno.h>
 #include <rados/librados.h>
 
 #include "ior.h"
@@ -27,47 +28,69 @@
 #include "aiori.h"
 #include "utilities.h"
 
+#define RADOS_ERR(__err_str, __ret) do { \
+        errno = -__ret; \
+        ERR(__err_str); \
+} while(0)
+
+/**************************** P R O T O T Y P E S *****************************/
+
+static void RADOS_Initialize(aiori_mod_opt_t *);
+static void RADOS_Finalize(aiori_mod_opt_t *);
+static aiori_fd_t *RADOS_Create(char *, int flags, aiori_mod_opt_t *);
+static aiori_fd_t *RADOS_Open(char *, int flags, aiori_mod_opt_t *);
+static IOR_offset_t RADOS_Xfer(int, aiori_fd_t *, IOR_size_t *,
+                           IOR_offset_t, IOR_offset_t, aiori_mod_opt_t *);
+static void RADOS_Close(aiori_fd_t *, aiori_mod_opt_t *);
+static void RADOS_Delete(char *, aiori_mod_opt_t *);
+static void RADOS_Fsync(aiori_fd_t *, aiori_mod_opt_t *);
+static IOR_offset_t RADOS_GetFileSize(aiori_mod_opt_t *, char *);
+static int RADOS_StatFS(const char *, ior_aiori_statfs_t *, aiori_mod_opt_t *);
+static int RADOS_MkDir(const char *, mode_t, aiori_mod_opt_t *);
+static int RADOS_RmDir(const char *, aiori_mod_opt_t *);
+static int RADOS_Access(const char *, int, aiori_mod_opt_t *);
+static int RADOS_Stat(const char *, struct stat *, aiori_mod_opt_t *);
+
 /************************** O P T I O N S *****************************/
-struct rados_options{
+typedef struct {
   char * user;
   char * conf;
   char * pool;
-};
+} RADOS_options_t;
+/***************************** F U N C T I O N S ******************************/
 
-static struct rados_options o = {
-  .user = NULL,
-  .conf = NULL,
-  .pool = NULL,
-};
+static option_help * RADOS_options(aiori_mod_opt_t ** init_backend_options, aiori_mod_opt_t * init_values){
+  RADOS_options_t * o = malloc(sizeof(RADOS_options_t));
 
-static option_help options [] = {
-      {0, "rados.user", "Username for the RADOS cluster", OPTION_REQUIRED_ARGUMENT, 's', & o.user},
-      {0, "rados.conf", "Config file for the RADOS cluster", OPTION_REQUIRED_ARGUMENT, 's', & o.conf},
-      {0, "rados.pool", "RADOS pool to use for I/O", OPTION_REQUIRED_ARGUMENT, 's', & o.pool},
-      LAST_OPTION
-};
+  if (init_values != NULL){
+    memcpy(o, init_values, sizeof(RADOS_options_t));
+  }else{
+    memset(o, 0, sizeof(RADOS_options_t));
+    /* initialize the options properly */
+    o->user = NULL;
+    o->conf = NULL;
+    o->pool = NULL;
+  }
 
+  *init_backend_options = (aiori_mod_opt_t*) o;
 
-/**************************** P R O T O T Y P E S *****************************/
-static void *RADOS_Create(char *, IOR_param_t *);
-static void *RADOS_Open(char *, IOR_param_t *);
-static IOR_offset_t RADOS_Xfer(int, void *, IOR_size_t *,
-                           IOR_offset_t, IOR_param_t *);
-static void RADOS_Close(void *, IOR_param_t *);
-static void RADOS_Delete(char *, IOR_param_t *);
-static void RADOS_Fsync(void *, IOR_param_t *);
-static IOR_offset_t RADOS_GetFileSize(IOR_param_t *, MPI_Comm, char *);
-static int RADOS_StatFS(const char *, ior_aiori_statfs_t *, IOR_param_t *);
-static int RADOS_MkDir(const char *, mode_t, IOR_param_t *);
-static int RADOS_RmDir(const char *, IOR_param_t *);
-static int RADOS_Access(const char *, int, IOR_param_t *);
-static int RADOS_Stat(const char *, struct stat *, IOR_param_t *);
-static option_help * RADOS_options();
+  option_help h [] = {
+    {0, "rados.user", "Username for the RADOS cluster", OPTION_REQUIRED_ARGUMENT, 's', & o->user},
+    {0, "rados.conf", "Config file for the RADOS cluster", OPTION_REQUIRED_ARGUMENT, 's', & o->conf},
+    {0, "rados.pool", "RADOS pool to use for I/O", OPTION_REQUIRED_ARGUMENT, 's', & o->pool},
+    LAST_OPTION
+  };
+  option_help * help = malloc(sizeof(h));
+  memcpy(help, h, sizeof(h));
+  return help;
+}
 
 /************************** D E C L A R A T I O N S ***************************/
 ior_aiori_t rados_aiori = {
         .name = "RADOS",
         .name_legacy = NULL,
+        .initialize = RADOS_Initialize,
+        .finalize = RADOS_Finalize,
         .create = RADOS_Create,
         .open = RADOS_Open,
         .xfer = RADOS_Xfer,
@@ -81,72 +104,66 @@ ior_aiori_t rados_aiori = {
         .rmdir = RADOS_RmDir,
         .access = RADOS_Access,
         .stat = RADOS_Stat,
-        .get_options = RADOS_options,
+        .get_options = RADOS_options
 };
 
-#define RADOS_ERR(__err_str, __ret) do { \
-        errno = -__ret; \
-        ERR(__err_str); \
-} while(0)
+static rados_t       rados_cluster;     /* RADOS cluster handle */
+static rados_ioctx_t rados_ioctx;       /* I/O context for our pool in the RADOS cluster */
 
 /***************************** F U N C T I O N S ******************************/
-static option_help * RADOS_options(){
-  return options;
-}
 
-static void RADOS_Cluster_Init(IOR_param_t * param)
+static void RADOS_Initialize(aiori_mod_opt_t * options)
 {
+        RADOS_options_t *o = (RADOS_options_t*) options;
         int ret;
 
         /* create RADOS cluster handle */
-        ret = rados_create(&param->rados_cluster, o.user);
+        ret = rados_create(&rados_cluster, o->user);
         if (ret)
                 RADOS_ERR("unable to create RADOS cluster handle", ret);
 
         /* set the handle using the Ceph config */
-        ret = rados_conf_read_file(param->rados_cluster, o.conf);
+        ret = rados_conf_read_file(rados_cluster, o->conf);
         if (ret)
                 RADOS_ERR("unable to read RADOS config file", ret);
 
         /* connect to the RADOS cluster */
-        ret = rados_connect(param->rados_cluster);
+        ret = rados_connect(rados_cluster);
         if (ret)
                 RADOS_ERR("unable to connect to the RADOS cluster", ret);
 
         /* create an io context for the pool we are operating on */
-        ret = rados_ioctx_create(param->rados_cluster, o.pool, &param->rados_ioctx);
+        ret = rados_ioctx_create(rados_cluster, o->pool, &rados_ioctx);
         if (ret)
                 RADOS_ERR("unable to create an I/O context for the RADOS cluster", ret);
 
         return;
 }
 
-static void RADOS_Cluster_Finalize(IOR_param_t * param)
+static void RADOS_Finalize(aiori_mod_opt_t * options)
 {
         /* ioctx destroy */
-        rados_ioctx_destroy(param->rados_ioctx);
+        rados_ioctx_destroy(rados_ioctx);
 
         /* shutdown */
-        rados_shutdown(param->rados_cluster);
+        rados_shutdown(rados_cluster);
 }
 
-static void *RADOS_Create_Or_Open(char *testFileName, IOR_param_t * param, int create_flag)
+static aiori_fd_t *RADOS_Create_Or_Open(char *testFileName, int flags, aiori_mod_opt_t *param)
 {
         int ret;
         char *oid;
-
-        RADOS_Cluster_Init(param);
 
         oid = strdup(testFileName);
         if (!oid)
                 ERR("unable to allocate RADOS oid");
 
-        if (create_flag)
+        if (flags & IOR_CREAT)
         {
                 rados_write_op_t create_op;
                 int rados_create_flag;
 
-                if (param->openFlags & IOR_EXCL)
+                if (flags & IOR_EXCL)
                         rados_create_flag = LIBRADOS_CREATE_EXCLUSIVE;
                 else
                         rados_create_flag = LIBRADOS_CREATE_IDEMPOTENT;
@@ -154,7 +171,7 @@ static void *RADOS_Create_Or_Open(char *testFileName, IOR_param_t * param, int c
                 /* create a RADOS "write op" for creating the object */
                 create_op = rados_create_write_op();
                 rados_write_op_create(create_op, rados_create_flag, NULL);
-                ret = rados_write_op_operate(create_op, param->rados_ioctx, oid,
+                ret = rados_write_op_operate(create_op, rados_ioctx, oid,
                                        NULL, 0);
                 rados_release_write_op(create_op);
                 if (ret)
@@ -165,24 +182,21 @@ static void *RADOS_Create_Or_Open(char *testFileName, IOR_param_t * param, int c
                 /* XXX actually, we should probably assert oid existence here? */
         }
 
-        return (void *)oid;
+        return (aiori_fd_t *)oid;
 }
 
-static void *RADOS_Create(char *testFileName, IOR_param_t * param)
+static aiori_fd_t *RADOS_Create(char *testFileName, int flags, aiori_mod_opt_t *param)
 {
-        return RADOS_Create_Or_Open(testFileName, param, TRUE);
+        return RADOS_Create_Or_Open(testFileName, flags, param);
 }
 
-static void *RADOS_Open(char *testFileName, IOR_param_t * param)
+static aiori_fd_t *RADOS_Open(char *testFileName, int flags, aiori_mod_opt_t *param)
 {
-        if (param->openFlags & IOR_CREAT)
-                return RADOS_Create_Or_Open(testFileName, param, TRUE);
-        else
-                return RADOS_Create_Or_Open(testFileName, param, FALSE);
+        return RADOS_Create_Or_Open(testFileName, flags, param);
 }
 
-static IOR_offset_t RADOS_Xfer(int access, void *fd, IOR_size_t * buffer,
-                               IOR_offset_t length, IOR_param_t * param)
+static IOR_offset_t RADOS_Xfer(int access, aiori_fd_t *fd, IOR_size_t * buffer,
+                               IOR_offset_t length, IOR_offset_t offset, aiori_mod_opt_t * param)
 {
         int ret;
         char *oid = (char *)fd;
@@ -193,8 +207,8 @@ static IOR_offset_t RADOS_Xfer(int access, void *fd, IOR_size_t * buffer,
 
                 write_op = rados_create_write_op();
                 rados_write_op_write(write_op, (const char *)buffer,
-                                     length, param->offset);
-                ret = rados_write_op_operate(write_op, param->rados_ioctx,
+                                     length, offset);
+                ret = rados_write_op_operate(write_op, rados_ioctx,
                                              oid, NULL, 0);
                 rados_release_write_op(write_op);
                 if (ret)
@@ -207,9 +221,9 @@ static IOR_offset_t RADOS_Xfer(int access, void *fd, IOR_size_t * buffer,
                 rados_read_op_t read_op;
 
                 read_op = rados_create_read_op();
-                rados_read_op_read(read_op, param->offset, length, (char *)buffer,
+                rados_read_op_read(read_op, offset, length, (char *)buffer,
                                    &bytes_read, &read_ret);
-                ret = rados_read_op_operate(read_op, param->rados_ioctx, oid, 0);
+                ret = rados_read_op_operate(read_op, rados_ioctx, oid, 0);
                 rados_release_read_op(read_op);
                 if (ret || read_ret || ((IOR_offset_t)bytes_read != length))
                         RADOS_ERR("unable to read RADOS object", ret);
@@ -218,47 +232,40 @@ static IOR_offset_t RADOS_Xfer(int access, void *fd, IOR_size_t * buffer,
         return length;
 }
 
-static void RADOS_Fsync(void *fd, IOR_param_t * param)
+static void RADOS_Fsync(aiori_fd_t *fd, aiori_mod_opt_t * param)
 {
         return;
 }
 
-static void RADOS_Close(void *fd, IOR_param_t * param)
+static void RADOS_Close(aiori_fd_t *fd, aiori_mod_opt_t * param)
 {
         char *oid = (char *)fd;
 
-        /* object does not need to be "closed", but we should tear the cluster down */
-        RADOS_Cluster_Finalize(param);
+        /* object does not need to be "closed" */
         free(oid);
 
         return;
 }
 
-static void RADOS_Delete(char *testFileName, IOR_param_t * param)
+static void RADOS_Delete(char *testFileName, aiori_mod_opt_t * param)
 {
         int ret;
         char *oid = testFileName;
         rados_write_op_t remove_op;
 
-        /* we have to reestablish cluster connection here... */
-        RADOS_Cluster_Init(param);
-
         /* remove the object */
         remove_op = rados_create_write_op();
         rados_write_op_remove(remove_op);
-        ret = rados_write_op_operate(remove_op, param->rados_ioctx,
+        ret = rados_write_op_operate(remove_op, rados_ioctx,
                                      oid, NULL, 0);
         rados_release_write_op(remove_op);
         if (ret)
                 RADOS_ERR("unable to remove RADOS object", ret);
 
-        RADOS_Cluster_Finalize(param);
-
         return;
 }
 
-static IOR_offset_t RADOS_GetFileSize(IOR_param_t * test, MPI_Comm testComm,
-                                      char *testFileName)
+static IOR_offset_t RADOS_GetFileSize(aiori_mod_opt_t *param, char *testFileName)
 {
         int ret;
         char *oid = testFileName;
@@ -267,84 +274,49 @@ static IOR_offset_t RADOS_GetFileSize(IOR_param_t * test, MPI_Comm testComm,
         int stat_ret;
         IOR_offset_t aggSizeFromStat, tmpMin, tmpMax, tmpSum;
 
-        /* we have to reestablish cluster connection here... */
-        RADOS_Cluster_Init(test);
-
         /* stat the object */
         stat_op = rados_create_read_op();
         rados_read_op_stat(stat_op, &oid_size, NULL, &stat_ret);
-        ret = rados_read_op_operate(stat_op, test->rados_ioctx, oid, 0);
+        ret = rados_read_op_operate(stat_op, rados_ioctx, oid, 0);
         rados_release_read_op(stat_op);
         if (ret || stat_ret)
                 RADOS_ERR("unable to stat RADOS object", stat_ret);
         aggSizeFromStat = oid_size;
 
-        if (test->filePerProc == TRUE)
-        {
-                MPI_CHECK(MPI_Allreduce(&aggSizeFromStat, &tmpSum, 1,
-                                        MPI_LONG_LONG_INT, MPI_SUM, testComm),
-                          "cannot total data moved");
-                aggSizeFromStat = tmpSum;
-        }
-        else
-        {
-                MPI_CHECK(MPI_Allreduce(&aggSizeFromStat, &tmpMin, 1,
-                                        MPI_LONG_LONG_INT, MPI_MIN, testComm),
-                          "cannot total data moved");
-                MPI_CHECK(MPI_Allreduce(&aggSizeFromStat, &tmpMax, 1,
-                                        MPI_LONG_LONG_INT, MPI_MAX, testComm),
-                          "cannot total data moved");
-                if (tmpMin != tmpMax)
-                {
-                        if (rank == 0)
-                                WARN("inconsistent file size by different tasks");
-
-                        /* incorrect, but now consistent across tasks */
-                        aggSizeFromStat = tmpMin;
-                }
-        }
-
-        RADOS_Cluster_Finalize(test);
-
         return aggSizeFromStat;
 }
 
 static int RADOS_StatFS(const char *oid, ior_aiori_statfs_t *stat_buf,
-                        IOR_param_t *param)
+                        aiori_mod_opt_t * param)
 {
         WARN("statfs not supported in RADOS backend!");
         return -1;
 }
 
-static int RADOS_MkDir(const char *oid, mode_t mode, IOR_param_t *param)
+static int RADOS_MkDir(const char *oid, mode_t mode, aiori_mod_opt_t * param)
 {
         WARN("mkdir not supported in RADOS backend!");
         return -1;
 }
 
-static int RADOS_RmDir(const char *oid, IOR_param_t *param)
+static int RADOS_RmDir(const char *oid, aiori_mod_opt_t * param)
 {
         WARN("rmdir not supported in RADOS backend!");
         return -1;
 }
 
-static int RADOS_Access(const char *oid, int mode, IOR_param_t *param)
+static int RADOS_Access(const char *oid, int mode, aiori_mod_opt_t * param)
 {
         rados_read_op_t read_op;
         int ret;
         int prval;
         uint64_t oid_size;
 
-        /* we have to reestablish cluster connection here... */
-        RADOS_Cluster_Init(param);
-
         /* use read_op stat to check for oid existence */
         read_op = rados_create_read_op();
         rados_read_op_stat(read_op, &oid_size, NULL, &prval);
-        ret = rados_read_op_operate(read_op, param->rados_ioctx, oid, 0);
+        ret = rados_read_op_operate(read_op, rados_ioctx, oid, 0);
         rados_release_read_op(read_op);
-
-        RADOS_Cluster_Finalize(param);
 
         if (ret | prval)
                 return -1;
@@ -352,7 +324,7 @@ static int RADOS_Access(const char *oid, int mode, IOR_param_t *param)
                 return 0;
 }
 
-static int RADOS_Stat(const char *oid, struct stat *buf, IOR_param_t *param)
+static int RADOS_Stat(const char *oid, struct stat *buf, aiori_mod_opt_t * param)
 {
         WARN("stat not supported in RADOS backend!");
         return -1;

--- a/src/ior.h
+++ b/src/ior.h
@@ -29,12 +29,6 @@
    typedef void*    hdfsFS;      /* unused, but needs a type */
 #endif
 
-#ifdef USE_RADOS_AIORI
-#  include <rados/librados.h>
-#else
-    typedef void *rados_t;
-    typedef void *rados_ioctx_t;
-#endif
 #include "option.h"
 #include "iordef.h"
 #include "aiori.h"
@@ -154,10 +148,6 @@ typedef struct
     int fsync;                       /* fsync() after write */
 
     char*       URI;                 /* "path" to target object */
-
-    /* RADOS variables */
-    rados_t rados_cluster;           /* RADOS cluster handle */
-    rados_ioctx_t rados_ioctx;       /* I/O context for our pool in the RADOS cluster */
 
     int id;                          /* test's unique ID */
     int intraTestBarriers;           /* barriers between open/op and op/close */


### PR DESCRIPTION
This PR contains the following fixes/updates for the RADOS backend for IOR:

* sync module API prototypes to current aiori interface
* errno.h must be included
* add init/finalize routines to setup/teardown RADOS cluster outside of typical I/O paths