### PR TITLE
strictly required to use struct timespec

### DIFF
--- a/src/md-workbench.c
+++ b/src/md-workbench.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 199309L
 #include <mpi.h>
 
 #include <time.h>


### PR DESCRIPTION
md-workbench compilation fails on a clean Ubuntu docker image because the size of `struct timespec` is unknown. This just fixes that by specifying we are coding to a version of POSIX C that defines `struct timespec`.

This bug goes back to the last IO500 tag upon which an upcoming ior-4.0.0 release will be based per #361.