### PR TITLE
userDoc: fix mentioning of IOR STOP and be more specific about case

### DIFF
--- a/doc/sphinx/userDoc/scripts.rst
+++ b/doc/sphinx/userDoc/scripts.rst
@@ -21,10 +21,10 @@ get applied until after the ``-f`` option (and its constituent runs) are complet
 Input scripts are specified using the long-form option names that correspond to
 each command-line option.  In addition to long-form options,
 
-    * ``IOR START`` and ``IOR STOP`` (case-insensitive) mark the beginning and end
-      of the script
+    * ``IOR START`` and ``IOR STOP`` (case-insensitive) mark the beginning and
+      end of the script.
     * ``RUN`` (case-insensitive) dispatches the test using all of the options
-       specified before it
+      specified before it.
     * All previous set parameter stay set for the next test. They are not reset
       to the default! For default the must be rest manually.
     * White space is ignored in script, as are comments starting with ``#``.

--- a/doc/sphinx/userDoc/scripts.rst
+++ b/doc/sphinx/userDoc/scripts.rst
@@ -23,7 +23,8 @@ each command-line option.  In addition to long-form options,
 
     * ``IOR START`` and ``IOR STOP`` (case-insensitive) mark the beginning and end
       of the script
-    * ``RUN`` dispatches the test using all of the options specified before it
+    * ``RUN`` (case-insensitive) dispatches the test using all of the options
+       specified before it
     * All previous set parameter stay set for the next test. They are not reset
       to the default! For default the must be rest manually.
     * White space is ignored in script, as are comments starting with ``#``.

--- a/doc/sphinx/userDoc/scripts.rst
+++ b/doc/sphinx/userDoc/scripts.rst
@@ -21,7 +21,8 @@ get applied until after the ``-f`` option (and its constituent runs) are complet
 Input scripts are specified using the long-form option names that correspond to
 each command-line option.  In addition to long-form options,
 
-    * ``IOR START`` and ``IOR END`` mark the beginning and end of the script
+    * ``IOR START`` and ``IOR STOP`` (case-insensitive) mark the beginning and end
+      of the script
     * ``RUN`` dispatches the test using all of the options specified before it
     * All previous set parameter stay set for the next test. They are not reset
       to the default! For default the must be rest manually.


### PR DESCRIPTION
I noticed IOR END being mentioned in the user documentation about scripting. There is IOR STOP instead.
Furthermore, those control words are parsed case-insensitively, which perhaps should be noted.
Which I did.
Please merge at your leisure.