### PR TITLE
ior: improve error for existing output file

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1199,7 +1199,8 @@ static void TestIoSys(IOR_test_t *test)
           GetTestFileName(testFileName, params);
           int ret = backend->stat(testFileName, & sb, params->backend_options);
           if(ret == 0) {
-            WARNF("The file \"%s\" exists already and will be overwritten", testFileName);
+            WARNF("The file \"%s\" exists already and will be %s", testFileName,
+		  params->useExistingTestFile ? "overwritten" : "deleted");
           }
         }
 


### PR DESCRIPTION
If the '-E' option is not used and existing output files are found, the current error message says that the files will be "overwritten" but this is not totally accurate.  Without '-E' the file will be deleted first, which makes a difference if the files were precreated with a specific layout.

Update the error to report that files will be deleted in this case.