### PR TITLE
Feature latency

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1759,7 +1759,7 @@ static IOR_offset_t WriteOrRead(IOR_param_t *test, int rep, IOR_results_t *resul
         if(test->savePerOpDataCSV != NULL) {
                 char fname[FILENAME_MAX];
                 sprintf(fname, "%s-%d-%05d.csv", test->savePerOpDataCSV, rep, rank);
-                ot = OpTimerInit(fname);
+                ot = OpTimerInit(fname, test->transferSize);
         }
         // start timer after random offset was generated        
         startForStonewall = GetTimeStamp();
@@ -1875,7 +1875,7 @@ static IOR_offset_t WriteOrRead(IOR_param_t *test, int rep, IOR_results_t *resul
           point->pairs_accessed = pairCnt;
         }
 
-        OpTimerFree(ot);
+        OpTimerFree(& ot);
         totalErrorCount += CountErrors(test, access, errors);
 
         if (access == WRITE && test->fsync == TRUE) {

--- a/src/ior.h
+++ b/src/ior.h
@@ -115,6 +115,7 @@ typedef struct
     IOR_offset_t expectedAggFileSize; /* calculated aggregate file size */
     IOR_offset_t randomPrefillBlocksize;   /* prefill option for random IO, the amount of data used for prefill */
 
+    char * savePerOpDataCSV;            /* save details about each I/O operation into this file */
     char * saveRankDetailsCSV;       /* save the details about the performance to a file */
     int summary_every_test;          /* flag to print summary every test, not just at end */
     int uniqueDir;                   /* use unique directory for each fpp */

--- a/src/mdtest.h
+++ b/src/mdtest.h
@@ -4,6 +4,7 @@
 #include <mpi.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <utilities.h>
 
 typedef enum {
   MDTEST_DIR_CREATE_NUM = 0,

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -118,6 +118,8 @@ void DecodeDirective(char *line, IOR_param_t *params, options_all_t * module_opt
             fclose(fd);
           }
           params->saveRankDetailsCSV = strdup(value);
+        } else if (strcasecmp(option, "savePerOpDataCSV") == 0){
+          params->savePerOpDataCSV = strdup(value);
         } else if (strcasecmp(option, "summaryFormat") == 0) {
                 if(strcasecmp(value, "default") == 0){
                   outputFormat = OUTPUT_DEFAULT;
@@ -473,6 +475,7 @@ option_help * createGlobalOptions(IOR_param_t * params){
     {.help="  -O summaryFile=FILE                 -- store result data into this file", .arg = OPTION_OPTIONAL_ARGUMENT},
     {.help="  -O summaryFormat=[default,JSON,CSV] -- use the format for outputting the summary", .arg = OPTION_OPTIONAL_ARGUMENT},
     {.help="  -O saveRankPerformanceDetailsCSV=<FILE> -- store the performance of each rank into the named CSV file.", .arg = OPTION_OPTIONAL_ARGUMENT},
+    {.help="  -O savePerOpDataCSV=<FILE> -- store the performance of each rank into an individual file prefixed with this option.", .arg = OPTION_OPTIONAL_ARGUMENT},
     {0, "dryRun",      "do not perform any I/Os just run evtl. inputs print dummy output", OPTION_FLAG, 'd', & params->dryRun},
     LAST_OPTION,
   };

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -235,6 +235,72 @@ int verify_memory_pattern(uint64_t item, char * buffer, size_t bytes, int rand_s
   return error;
 }
 
+/* Data structure to store information about per-operation timer */
+struct OpTimer{
+    FILE * fd;
+    double * time;
+    double * value;
+    int pos;
+};
+
+/* by default store 1M operations into the buffer before flushing */
+#define OP_BUFFER_SIZE 1000000
+
+OpTimer* OpTimerInit(char * filename){
+  if(filename == NULL) {
+    return NULL;
+  }
+  OpTimer * ot = safeMalloc(sizeof(OpTimer));
+  ot->value = safeMalloc(sizeof(double)*OP_BUFFER_SIZE);
+  ot->time = safeMalloc(sizeof(double)*OP_BUFFER_SIZE);
+  ot->pos = 0;
+  ot->fd = fopen(filename, "w");
+  if(ot->fd < 0){
+    ERR("Could not create OpTimer");
+  }
+  char buff[] = "time,runtime\n";
+  int ret = fwrite(buff, strlen(buff), 1, ot->fd);
+  if(ret != 1){
+    FAIL("Cannot write header to OpTimer file");
+  }
+  return ot;
+}
+
+void OpTimerFlush(OpTimer* ot){
+  if(ot == NULL) {
+    return;
+  }  
+  for(int i=0; i < ot->pos; i++){
+    fprintf(ot->fd, "%.8e,%.8e\n", ot->time[i], ot->value[i]);
+  }
+  ot->pos = 0;
+}
+
+void OpTimerValue(OpTimer* ot, double now, double runTime){
+  if(ot == NULL) {
+    return;
+  }  
+  ot->time[ot->pos] = now;
+  ot->value[ot->pos++] = runTime;
+  if(ot->pos == OP_BUFFER_SIZE){
+    OpTimerFlush(ot);
+  }
+}
+
+void OpTimerFree(OpTimer* ot){
+  if(ot == NULL) {
+    return;
+  }    
+  OpTimerFlush(ot);
+  ot->pos = 0;
+  free(ot->value);
+  free(ot->time);
+  ot->value = NULL;
+  ot->time = NULL;
+  fclose(ot->fd);
+  free(ot);
+}
+
 void* safeMalloc(uint64_t size){
   void * d = malloc(size);
   if (d == NULL){

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -64,6 +64,12 @@ void DelaySecs(int delay);
 void updateParsedOptions(IOR_param_t * options, options_all_t * global_options);
 size_t NodeMemoryStringToBytes(char *size_str);
 
+typedef struct OpTimer OpTimer;
+OpTimer* OpTimerInit(char * filename);
+void OpTimerValue(OpTimer* otimer_in, double now, double runTime);
+void OpTimerFlush(OpTimer* otimer_in);
+void OpTimerFree(OpTimer* otimer_in);
+
 /* Returns -1, if cannot be read  */
 int64_t ReadStoneWallingIterations(char * const filename, MPI_Comm com);
 void StoreStoneWallingIterations(char * const filename, int64_t count);

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -65,10 +65,10 @@ void updateParsedOptions(IOR_param_t * options, options_all_t * global_options);
 size_t NodeMemoryStringToBytes(char *size_str);
 
 typedef struct OpTimer OpTimer;
-OpTimer* OpTimerInit(char * filename);
+OpTimer* OpTimerInit(char * filename, int size);
 void OpTimerValue(OpTimer* otimer_in, double now, double runTime);
 void OpTimerFlush(OpTimer* otimer_in);
-void OpTimerFree(OpTimer* otimer_in);
+void OpTimerFree(OpTimer** otimer_in);
 
 /* Returns -1, if cannot be read  */
 int64_t ReadStoneWallingIterations(char * const filename, MPI_Comm com);


### PR DESCRIPTION
This branch allows to store per-operation information from mdtest and IOR by using the savePerOpDataCSV option.
One file is created per rank so beware, it can be huge!
The timing per operation is stored for up to 1M values per rank and then flushed to the CSV file. 
Do not store the CSV files on the same storage as the one you are testing.

It does support #463 a bit, by allowing to later extract time intervals as needed.