### PR TITLE
Add support for params->useExistingTestFile to DFS backend

### DIFF
--- a/src/aiori-DFS.c
+++ b/src/aiori-DFS.c
@@ -664,11 +664,14 @@ DFS_Create(char *testFileName, int flags, aiori_mod_opt_t *param)
 
         mode = S_IFREG | mode;
 	if (hints->filePerProc || rank == 0) {
-                fd_oflag |= O_CREAT | O_RDWR | O_EXCL;
+                fd_oflag |= O_CREAT | O_RDWR;
 
                 parent = lookup_insert_dir(dir_name, NULL);
                 if (parent == NULL)
                         DERR("Failed to lookup parent: %s", dir_name);
+
+                if (flags & IOR_EXCL)
+                        fd_oflag |= O_EXCL;
 
                 rc = dfs_open(dfs, parent, name, mode, fd_oflag,
                               objectClass, o->chunk_size, NULL, &obj);


### PR DESCRIPTION
O_EXCL should not be used on dfs_open() if not instructed to use it explicitely.

Otherwise, it fails when using -E as follows:

ERROR (aiori-DFS.c:675): 2: 17: dfs_open() of foo.00000002 Failed
03/19/2024 15:44:27: Process 2: FAILED in TestIoSys, Cannot create file
Abort(1) on node 2 (rank 2 in comm 496): application called MPI_Abort(comm=0x84000004, 1) - process 2