### PR TITLE
Fix strict-prototype error

### DIFF
--- a/src/utilities.h
+++ b/src/utilities.h
@@ -76,7 +76,7 @@ void StoreStoneWallingIterations(char * const filename, int64_t count);
 
 void init_clock(MPI_Comm com);
 double GetTimeStamp(void);
-char * PrintTimestamp(); // TODO remove this function
+char * PrintTimestamp(void); // TODO remove this function
 unsigned long GetProcessorAndCore(int *chip, int *core);
 void *aligned_buffer_alloc(size_t size, ior_memory_flags type);
 void aligned_buffer_free(void *buf, ior_memory_flags type);


### PR DESCRIPTION
At least the IO500 compiles IOR with `-Werror=strict-prototypes`, the missing `void` in the argument list causes a compilation error. This commit fix this.