### PR TITLE
src/aiori-CEPHFS: re-enable mdtest support.

### DIFF
--- a/src/aiori-CEPHFS.c
+++ b/src/aiori-CEPHFS.c
@@ -111,6 +111,7 @@ ior_aiori_t cephfs_aiori = {
         .access = CEPHFS_Access,
         .stat = CEPHFS_Stat,
         .sync = CEPHFS_Sync,
+        .enable_mdtest = true,
 };
 
 #define CEPHFS_ERR(__err_str, __ret) do { \


### PR DESCRIPTION
Re-enable mdtest for the CephFS aiori backend.