### PR TITLE
Fix a couple of minor issues with IOR output

### DIFF
--- a/src/aiori-aio.c
+++ b/src/aiori-aio.c
@@ -84,7 +84,6 @@ static void aio_initialize(aiori_mod_opt_t * param){
   if(io_setup(o->max_pending, & o->ioctx) != 0){
     ERRF("Couldn't initialize io context %s", strerror(errno));
   }
-  printf("%d\n", (o->max_pending));
 
   o->iocbs = malloc(sizeof(struct iocb *) * o->granularity);
   o->iocbs_pos = 0;

--- a/src/ior.c
+++ b/src/ior.c
@@ -194,15 +194,15 @@ int ior_main(int argc, char **argv)
     out_logfile = stdout;
     out_resultfile = stdout;
 
-    /*
-     * check -h option from commandline without starting MPI;
-     */
-    tests_head = ParseCommandLine(argc, argv, MPI_COMM_WORLD);
-
     /* start the MPI code */
     MPI_CHECK(MPI_Init(&argc, &argv), "cannot initialize MPI");
 
     MPI_CHECK(MPI_Comm_rank(MPI_COMM_WORLD, &rank), "cannot get rank");
+
+    /*
+     * check -h option from commandline without starting MPI;
+     */
+    tests_head = ParseCommandLine(argc, argv, MPI_COMM_WORLD);
 
     /* set error-handling */
     /*MPI_CHECK(MPI_Errhandler_set(mpi_comm_world, MPI_ERRORS_RETURN),


### PR DESCRIPTION
This commit fixes two issues:

 - The AIO backend prints the max outstanding transactions when starting. This is printed by every MPI rank and doesn't add much. Probably is left over from some debugging.

 - Init MPI ***before*** parsing the command line. Without this every rank thinks it is rank 0 so messages that should only be printed by rank 0 are printed n times.