### PR TITLE
mdtest: fix time units in summary

### DIFF
--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -1566,7 +1566,11 @@ static void summarize_results_rank0(int iterations,  mdtest_results_t * all_resu
     }
   }
 
-  VERBOSE(0, -1, "\nSUMMARY %s (in ops/sec): (of %d iterations)", print_time ? "time" : "rate", iterations);
+  if(print_time){
+    VERBOSE(0, -1, "\nSUMMARY time (in ms/op): (of %d iterations)", iterations);
+  }else{
+    VERBOSE(0, -1, "\nSUMMARY rate (in ops/sec): (of %d iterations)", iterations);
+  }
   PRINT("   Operation     ");
   if(o.show_perrank_statistics){
     PRINT("per Rank: Max            Min           Mean      per Iteration:");


### PR DESCRIPTION
When time is printed in the summary (option -Z), then display units should be time-per-op, instead of hard coded ops-per-second.

Before change:

SUMMARY time (in ops/sec): (of 1 iterations)

After:

SUMMARY time (in ms/op): (of 1 iterations)