### PR TITLE
Update behaviour of reorderTasksRandom to shuffle ranks and not just rankOffsets.

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -1365,7 +1365,7 @@ static void TestIoSys(IOR_test_t *test)
                                         file_hits_histogram(params);
                                 }
                         }
-                        if (params->reorderTasksRandom > 1) { /* Shuffling rank offset */
+                        if (params->reorderTasksRandom > 1) { /* Shuffling ranks for read back */
                                 int nodeoffset;
                                 unsigned int iseed0;
                                 nodeoffset = params->taskPerNodeOffset;
@@ -1387,7 +1387,7 @@ static void TestIoSys(IOR_test_t *test)
                                         rankOffsets[tgt] = rankOffsets[i];
                                         rankOffsets[i] = tmp;
                                 }
-                                rankOffset = rankOffsets[rank];
+                                rankOffset = rankOffsets[rank] - rank;
                                 free(rankOffsets);
                         }
                         /* Using globally passed rankOffset, following function generates testFileName to read */


### PR DESCRIPTION
With the current behaviour, when specifying `reorderTasksRandom` multiple times with `-Z -Z`, the offsets for readback are shuffled, but since the rank that does the read operation is decided by `rank + rankOffset` the result is that multiple ranks can/will end up reading the same data. This can lead to a (superficial) increase to the reported read performance as data can be cached on a client and given to multiple ranks.

Instead, if we shuffle the `rankOffset` as is done currently and then subtract the current rank, this will ensure that the ranks that do the read operations are a true permutation of the write ranks.

This is related to https://github.com/hpc/ior/issues/500