### PR TITLE
WIP: Delete file to trigger any "first touch" calls

### DIFF
--- a/src/aiori-MPIIO.c
+++ b/src/aiori-MPIIO.c
@@ -626,8 +626,7 @@ void MPIIO_Delete(char *testFileName, aiori_mod_opt_t * module_options)
   mpiio_options_t * param = (mpiio_options_t*) module_options;
   if(hints->dryRun)
     return;
-  MPI_CHECKF(MPI_File_delete(testFileName, (MPI_Info) MPI_INFO_NULL),
-             "cannot delete file: %s", testFileName);
+  MPI_File_delete(testFileName, (MPI_Info) MPI_INFO_NULL);
 }
 
 /*

--- a/src/ior.c
+++ b/src/ior.c
@@ -1195,6 +1195,12 @@ static void TestIoSys(IOR_test_t *test)
           }
         }
 
+#ifndef IOR_SKIP_DELETE
+        /* touch the file system to load up any client-side libraries */
+        GetTestFileName(testFileName, params);
+        backend->delete(testFileName, params->backend_options);
+#endif
+
         for (rep = 0; rep < params->repetitions; rep++) {
                 /* Get iteration start time in seconds in task 0 and broadcast to
                    all tasks */


### PR DESCRIPTION
Some storage systems (DAOS, PVFS, possibly others) do a "library init" the very first time a program calls MPI_File_Open or MPI_File_delete.

In some ways it's entirely fair to include these first touch time but it can also obscure the effects of optimizations or tuning to have one of the iterations consistently take 10x longer.

Since I don't know if this is a good idea or not, I thought I'd fire off this pull request to see if the community had any thoughts