### PR TITLE
Add --memoryAlign to allocate huge-page-backed I/O buffers

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -906,6 +906,7 @@ static void InitTests(IOR_test_t *tests)
 static void XferBuffersSetup(IOR_io_buffers* ioBuffers, IOR_param_t* test,
                              int pretendRank)
 {
+        aligned_buffer_set_alignment((size_t) test->memoryAlign);
         ioBuffers->buffer = aligned_buffer_alloc(test->transferSize, test->gpuMemoryFlags);
 }
 
@@ -1478,6 +1479,15 @@ static void ValidateTests(IOR_param_t * test, MPI_Comm com)
         IOR_param_t defaults;
         init_IOR_Param_t(&defaults, com);
 
+        if (test->memoryAlign != 0) {
+          uint64_t pageSize = (uint64_t) sysconf(_SC_PAGESIZE);
+          if (test->memoryAlign & (test->memoryAlign - 1))
+            ERR("memoryAlign must be a power of two");
+          if (test->memoryAlign < pageSize)
+            ERR("memoryAlign must be at least the system page size");
+          if (test->memoryAlign > (uint64_t) 1 << 30)
+            ERR("memoryAlign is unreasonably large (> 1g)");
+        }
         if (test->gpuDirect && test->gpuMemoryFlags == IOR_MEMORY_TYPE_CPU )
           ERR("GPUDirect requires a non-CPU memory type");
         if (test->gpuMemoryFlags == IOR_MEMORY_TYPE_GPU_DEVICE_ONLY && ! test->gpuDirect )

--- a/src/ior.h
+++ b/src/ior.h
@@ -135,6 +135,7 @@ typedef struct
     int randomSeed;                  /* random seed for write/read check */
     unsigned int incompressibleSeed; /* random seed for incompressible file creation */
     int randomOffset;                /* access is to random offsets */
+    uint64_t memoryAlign;            /* alignment of I/O buffers, 0 = page size */
     size_t memoryPerTask;            /* additional memory used per task */
     size_t memoryPerNode;            /* additional memory used per node */
     char * memoryPerNodeStr;         /* for parsing */

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -449,6 +449,7 @@ option_help * createGlobalOptions(IOR_param_t * params){
     {'K', NULL,        "keepFileWithError  -- keep error-filled file(s) after data-checking", OPTION_FLAG, 'd', & params->keepFileWithError},
     {'l', "dataPacketType",        "datapacket type-- type of packet that will be created [offset|incompressible|timestamp|random|o|i|t|r]", OPTION_OPTIONAL_ARGUMENT, 's', &  params->buffer_type},
     {'m', NULL,        "multiFile -- use number of reps (-i) for multiple file count", OPTION_FLAG, 'd', & params->multiFile},
+    {0, "memoryAlign", "align I/O buffers to this boundary instead of the page size (e.g.: 2m); on Linux the buffer is also advised MADV_HUGEPAGE, so this is how to obtain huge-page-backed I/O buffers", OPTION_OPTIONAL_ARGUMENT, 'u', & params->memoryAlign},
     {'M', NULL,        "memoryPerNode -- hog memory on the node  (e.g.: 2g, 75%)", OPTION_OPTIONAL_ARGUMENT, 's', & params->memoryPerNodeStr},
     {'N', NULL,        "numTasks -- number of tasks that are participating in the test (overrides MPI)", OPTION_OPTIONAL_ARGUMENT, 'd', & params->numTasks},
     {'o', NULL,        "testFile -- full name for test", OPTION_OPTIONAL_ARGUMENT, 's', & params->testFileName},

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -37,6 +37,10 @@
 #include <sys/types.h>
 #include <time.h>
 
+#ifdef __linux__
+#  include <sys/mman.h>          /* madvise() */
+#endif
+
 #ifdef HAVE_CUDA
 #include <cuda_runtime.h>
 #endif
@@ -1157,6 +1161,21 @@ unsigned long GetProcessorAndCore(int *chip, int *core){
 
 
 
+/* Alignment applied to I/O buffers; 0 means the system page size, which is
+   all O_DIRECT requires.  See aligned_buffer_set_alignment(). */
+static size_t memoryAlignment = 0;
+
+/*
+ * Set the alignment used by aligned_buffer_alloc() for subsequent
+ * allocations.  A value of 0 restores the default (the system page size).
+ * Must be a power of two and at least the page size; the caller is
+ * responsible for validating that.
+ */
+void aligned_buffer_set_alignment(size_t alignment)
+{
+  memoryAlignment = alignment;
+}
+
 /*
  * Allocate a page-aligned (required by O_DIRECT) buffer.
  */
@@ -1188,16 +1207,36 @@ void *aligned_buffer_alloc(size_t size, ior_memory_flags type)
     }
 
 #ifdef HAVE_SYSCONF
-  long pageSize = sysconf(_SC_PAGESIZE);
+  size_t pageSize = (size_t) sysconf(_SC_PAGESIZE);
 #else
   size_t pageSize = getpagesize();
 #endif
+  size_t alignment = memoryAlignment ? memoryAlignment : pageSize;
+  size_t total;
 
-  pageMask = pageSize - 1;
-  buf = safeMalloc(size + pageSize + sizeof(void *));
+  pageMask = alignment - 1;
+  total = size + alignment + sizeof(void *);
+  buf = malloc(total);
+  if (buf == NULL)
+    ERR("Could not allocate an aligned buffer");
   /* find the alinged buffer */
   tmp = buf + sizeof(char *);
-  aligned = tmp + pageSize - ((size_t) tmp & pageMask);
+  aligned = tmp + alignment - ((size_t) tmp & pageMask);
+
+#ifdef MADV_HUGEPAGE
+  /* Ask for huge pages before the buffer is first touched: once a page has
+     been faulted in as a base page, only khugepaged can collapse it, which
+     is asynchronous and may not happen at all during a short run.  Only the
+     aligned region is advised -- madvise() requires a page-aligned start,
+     which the malloc()ed pointer is not.  A failure here is not fatal, the
+     buffer is simply backed by base pages. */
+  if (alignment > pageSize)
+    (void) madvise(aligned, size, MADV_HUGEPAGE);
+#endif
+
+  /* matches the zeroing that safeMalloc() used to provide */
+  memset(buf, 0, total);
+
   /* write a pointer to the original malloc()ed buffer into the bytes
      preceding "aligned", so that the aligned buffer can later be free()ed */
   tmp = aligned - sizeof(void *);

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -78,6 +78,7 @@ void init_clock(MPI_Comm com);
 double GetTimeStamp(void);
 char * PrintTimestamp(void); // TODO remove this function
 unsigned long GetProcessorAndCore(int *chip, int *core);
+void aligned_buffer_set_alignment(size_t alignment);
 void *aligned_buffer_alloc(size_t size, ior_memory_flags type);
 void aligned_buffer_free(void *buf, ior_memory_flags type);
 


### PR DESCRIPTION
### Problem

`aligned_buffer_alloc()` aligns I/O buffers to the system page size, which is all `O_DIRECT` requires. Whether the buffer then ends up huge-page-backed is left entirely to the system THP policy and to where the allocator happened to land.

Measured on a 5.14 kernel, `AnonHugePages` over the buffer's VMA:

| buffer | `transparent_hugepage=always` | `transparent_hugepage=madvise` |
|---|---|---|
| 4 / 16 / 64 MiB, stock 4KiB alignment | **already 100%** | 0% |
| 1 MiB, stock 4KiB alignment | 0% | 0% |
| 2MiB-aligned + `MADV_HUGEPAGE` | 100% | **100%** |

So on the common `always` policy a large buffer is already fully backed, and this option changes nothing for it. The two cases it addresses are the other rows:

- Under the `madvise` policy nothing is backed, at any size.
- Below the PMD size nothing is backed under either policy: a sub-PMD buffer needs a multi-size THP, and those require the region to be *naturally aligned* to the folio order, which a 4KiB-aligned buffer is not.

That matters when benchmarking a data path that behaves differently for huge-page-backed user buffers -- one that pins user pages and coalesces runs of pages belonging to the same folio, say, or one registering buffers for RDMA. Today IOR cannot *ask* for such a buffer. It gets one by luck of a global system setting the benchmark does not record, and cannot get one at all for small transfers or on a `madvise`-policy machine.

I hit this measuring a Lustre change that collapses per-page bookkeeping when the user buffer is folio-backed.

### Change

`--memoryAlign=SIZE` aligns I/O buffers to the given boundary and, on Linux, advises `MADV_HUGEPAGE` over the buffer. Aligning to 2MiB is naturally aligned for every smaller order too, so one option covers PMD THP and every mTHP order.

**The default is unchanged**: 0 means the system page size and no `madvise()` call.

Two details that turned out to matter:

- The `madvise()` has to happen **before** the buffer is first touched. Once a page has been faulted in as a base page, only khugepaged can collapse it, which is asynchronous and may not happen during a short run. `safeMalloc()` zeroes the buffer immediately, so this path now uses `malloc()` plus an explicit `memset()` after the `madvise()`, keeping the same zeroing contract.
- Only the aligned region is advised, since `madvise()` requires a page-aligned start and the `malloc()`ed pointer is not one.

Rejected at validation: non-power-of-two, below the page size, above 1g.

### Testing

`thp_fault_alloc` delta across an IOR run with `transparent_hugepage=madvise`, so `MADV_HUGEPAGE` is required rather than merely helpful:

| transfer | default | `--memoryAlign=2m` |
|---|---|---|
| 4m | 0 | 2 |
| 16m | 0 | 8 |

Counts match the transfer size exactly (4MiB = 2 huge pages, 16MiB = 8), so the whole buffer is backed rather than part of it.

`strace` confirms the advised length is correct at sub-huge-page transfer sizes, where rounding the length down to a huge-page multiple would pass 0:

```
t=64k  --memoryAlign=2m  madvise(0x1c00000, 65536, MADV_HUGEPAGE) = 0
t=1m   --memoryAlign=2m  madvise(0x1600000, 1048576, MADV_HUGEPAGE) = 0
t=4m   --memoryAlign=2m  madvise(0x1200000, 4194304, MADV_HUGEPAGE) = 0
t=*    default           <no madvise call>
```

`O_DIRECT` works in both modes.

On the VM used here, write bandwidth over 5 iterations is unchanged: medians 2418 vs 2341 MiB/s, well inside that setup's run-to-run spread. **That is a no-regression check, not a measure of the benefit.** On real hardware, write bandwidth is much faster with huge-page-backed buffers in some cases -- which is the point of the option. A VM whose storage is the bottleneck cannot show that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
