### PR TITLE
gpu: fix hipFile probe, cuFile error handling, and driver teardown

### DIFF
--- a/config/ax_prog_cc_mpi.m4
+++ b/config/ax_prog_cc_mpi.m4
@@ -82,6 +82,9 @@ AC_PREREQ(2.50)
 # order.
 AC_REQUIRE([_AX_PROG_CC_MPI],[_AX_PROG_CC_MPI([$1])])
 
+# Enable extensions after selecting the compiler, before testing MPI.
+AC_REQUIRE([AC_USE_SYSTEM_EXTENSIONS])
+
 AS_IF([test x"$_ax_prog_cc_mpi_mpi_wanted" = xno],
   [ _ax_prog_cc_mpi_mpi_found=no ],
   [

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ AX_PROG_CC_MPI(,,[
 ])
 
 AC_PROG_RANLIB
+AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_CC
 
 # Checks for libraries.
@@ -311,7 +312,8 @@ AC_CHECK_FUNCS
 # Check for system capabilities
 AC_SYS_LARGEFILE
 
-AC_DEFINE([_XOPEN_SOURCE], [700], [C99 compatibility])
+# Use the guarded template supplied by AC_USE_SYSTEM_EXTENSIONS.
+AC_DEFINE([_XOPEN_SOURCE], [700])
 
 # Check for lustre availability
 AC_ARG_WITH([lustre],
@@ -726,7 +728,6 @@ AC_COMPILE_IFELSE(
 
 AC_COMPILE_IFELSE(
   [AC_LANG_SOURCE([[
-      #define _GNU_SOURCE
       #include <unistd.h>
       #include <sys/syscall.h>
       unsigned long GetProcessorAndCore(int *chip, int *core){

--- a/configure.ac
+++ b/configure.ac
@@ -278,8 +278,9 @@ AS_IF([test "x$gpu_direct_backend" = xhipfile], [
                 HIPFILE_LDFLAGS="-L$hipfile_prefix/lib -L$hipfile_prefix/lib64 -Wl,--enable-new-dtags -Wl,-rpath=$hipfile_prefix/lib:$hipfile_prefix/lib64"
         ])
         save_CPPFLAGS="$CPPFLAGS"; save_LDFLAGS="$LDFLAGS"; save_LIBS="$LIBS"
-        CPPFLAGS="$CPPFLAGS $HIPFILE_CPPFLAGS"
-        LDFLAGS="$LDFLAGS $HIPFILE_LDFLAGS"
+        CPPFLAGS="$CPPFLAGS $HIP_CPPFLAGS $HIPFILE_CPPFLAGS"
+        LDFLAGS="$LDFLAGS $HIP_LDFLAGS $HIPFILE_LDFLAGS"
+        LIBS="$HIP_LIBS $LIBS"
         AC_CHECK_HEADERS([hipfile.h], [], [
                 AC_MSG_FAILURE([hipFile backend selected, but hipfile.h not found])
         ])

--- a/src/aiori-HDFS.c
+++ b/src/aiori-HDFS.c
@@ -67,9 +67,7 @@
 
 #ifdef __linux__
 # include <sys/ioctl.h>          /* necessary for: */
-# define __USE_GNU               /* O_DIRECT and */
 # include <fcntl.h>              /* IO operations */
-# undef __USE_GNU
 #endif                          /* __linux__ */
 
 #include <errno.h>

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -765,7 +765,7 @@ static IOR_offset_t POSIX_Xfer(int access, aiori_fd_t *file, IOR_size_t * buffer
                         if(o->gpuDirect){
                           gpu_io_result_t gio_res;
                           char errbuf[256];
-                          gio_res = gpu_io_write(pfd->gpu_file, ptr, remaining,
+                          gio_res = gpu_io_write(pfd->gpu_file, buffer, remaining,
                                                   offset + mem_offset, mem_offset);
                           rc = gio_res.nbytes;
                           if(rc < 0){
@@ -795,7 +795,7 @@ static IOR_offset_t POSIX_Xfer(int access, aiori_fd_t *file, IOR_size_t * buffer
                         if(o->gpuDirect){
                           gpu_io_result_t gio_res;
                           char errbuf[256];
-                          gio_res = gpu_io_read(pfd->gpu_file, ptr, remaining,
+                          gio_res = gpu_io_read(pfd->gpu_file, buffer, remaining,
                                                  offset + mem_offset, mem_offset);
                           rc = gio_res.nbytes;
                           if(rc < 0){

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -939,8 +939,28 @@ IOR_offset_t POSIX_GetFileSize(aiori_mod_opt_t * test, char *testFileName)
         return (aggFileSizeFromStat);
 }
 
+#ifdef HAVE_GPU_DIRECT
+static unsigned int posix_init_count;
+#endif
+
 void POSIX_Initialize(aiori_mod_opt_t * options){
+#ifdef HAVE_GPU_DIRECT
+    ++posix_init_count;
+#endif
 }
 
 void POSIX_Finalize(aiori_mod_opt_t * options){
+#ifdef HAVE_GPU_DIRECT
+    gpu_io_status_t st;
+    char errbuf[256];
+
+    if (posix_init_count == 0)
+        return;
+    if (--posix_init_count != 0)
+        return;
+    st = gpu_io_shutdown();
+    if (!gpu_io_status_ok(st))
+        ERRF("GPU I/O shutdown failed: %s",
+             gpu_io_strerror(st, errbuf, sizeof(errbuf)));
+#endif
 }

--- a/src/aiori-POSIX.c
+++ b/src/aiori-POSIX.c
@@ -21,9 +21,7 @@
 
 #ifdef __linux__
 #  include <sys/ioctl.h>          /* necessary for: */
-#  define __USE_GNU               /* O_DIRECT and */
 #  include <fcntl.h>              /* IO operations */
-#  undef __USE_GNU
 #endif                          /* __linux__ */
 
 #include <errno.h>

--- a/src/gpu_io.h
+++ b/src/gpu_io.h
@@ -29,6 +29,7 @@ const char  *gpu_io_strerror(gpu_io_status_t status, char *buf, size_t buflen);
 
 gpu_io_status_t gpu_io_driver_open(void);
 gpu_io_status_t gpu_io_driver_close(void);
+gpu_io_status_t gpu_io_shutdown(void);
 
 gpu_io_status_t gpu_io_register_fd(gpu_io_file_t **file, int fd);
 void gpu_io_deregister_fd(gpu_io_file_t **file);

--- a/src/gpu_io_cufile.c
+++ b/src/gpu_io_cufile.c
@@ -143,12 +143,18 @@ gpu_io_deregister_fd(gpu_io_file_t **file)
 /*
  * cuFileRead/Write return:
  *   >= 0 : bytes transferred
- *   < 0  : negative CUfileOpError_t.  Use CUFILE_ERRSTR(-rc).
+ *   == -1: POSIX error in errno
+ *   < -1 : negative CUfileOpError_t. Use CUFILE_ERRSTR(-rc).
  */
 static void
 cufile_xfer_decode(gpu_io_result_t *res)
 {
-    if (res->nbytes < 0) {
+    if (res->nbytes == -1) {
+        int saved_errno = errno;
+        res->status.ok = 0;
+        res->status.errnum = saved_errno;
+        res->status.message = strerror(saved_errno);
+    } else if (res->nbytes < -1) {
         int raw_err = (int) -res->nbytes;
 
         res->status.ok = 0;

--- a/src/gpu_io_cufile.c
+++ b/src/gpu_io_cufile.c
@@ -88,6 +88,20 @@ gpu_io_driver_close(void)
 static int gpu_io_driver_opened = 0;
 
 gpu_io_status_t
+gpu_io_shutdown(void)
+{
+    gpu_io_status_t st = {0};
+    st.ok = 1;
+    if (!gpu_io_driver_opened)
+        return st;
+
+    st = gpu_io_driver_close();
+    if (gpu_io_status_ok(st))
+        gpu_io_driver_opened = 0;
+    return st;
+}
+
+gpu_io_status_t
 gpu_io_register_fd(gpu_io_file_t **file, int fd)
 {
     CUfileDescr_t descr;

--- a/src/gpu_io_hipfile.c
+++ b/src/gpu_io_hipfile.c
@@ -92,12 +92,35 @@ gpu_io_driver_close(void)
     return hipfile_to_status(err);
 }
 
-/* hipFileHandleRegister() auto-initializes the library on first call. */
+static int gpu_io_driver_opened = 0;
+
+gpu_io_status_t
+gpu_io_shutdown(void)
+{
+    gpu_io_status_t st = {0};
+    st.ok = 1;
+    if (!gpu_io_driver_opened)
+        return st;
+
+    st = gpu_io_driver_close();
+    if (gpu_io_status_ok(st))
+        gpu_io_driver_opened = 0;
+    return st;
+}
+
+/* Open lazily and release the owned driver session at shutdown. */
 gpu_io_status_t
 gpu_io_register_fd(gpu_io_file_t **file, int fd)
 {
     hipFileDescr_t descr;
     hipFileError_t err;
+
+    if (!gpu_io_driver_opened) {
+        gpu_io_status_t open_st = gpu_io_driver_open();
+        if (!gpu_io_status_ok(open_st))
+            return open_st;
+        gpu_io_driver_opened = 1;
+    }
 
     *file = (gpu_io_file_t *) malloc(sizeof(gpu_io_file_t));
     if (*file == NULL) {

--- a/src/utilities-gpu-h.hip
+++ b/src/utilities-gpu-h.hip
@@ -61,8 +61,6 @@ extern "C" void generate_memory_pattern_gpu(char * buf, size_t bytes, int rand_s
 
 extern "C" void update_write_memory_pattern_gpu(uint64_t item, char * buf, size_t bytes, int rand_seed, int rank, ior_dataPacketType_e dataPacketType){
   // nothing to do for dataPacketType == DATA_TIMESTAMP, i.e., won't be called for this parameter
-  size_t blocks = (bytes+2047)/2048;
-  size_t threads = 256;
 }
 
 extern "C" int verify_memory_pattern_gpu(uint64_t item, char * buffer, size_t bytes, int rand_seed, int pretendRank, ior_dataPacketType_e dataPacketType){

--- a/src/utilities-gpu-h.hip
+++ b/src/utilities-gpu-h.hip
@@ -36,7 +36,7 @@ void cu_verify_memory_timestamp(uint64_t item, uint64_t * buf, size_t length, in
   if(pos < length){
     int correct = buf[pos] == (pretendRank | rand_seed + pos);
     if(! correct){
-      *errors = 1; // it isn't thread safe but one error reported is enough
+      atomicExch(errors, 1);
     }
   }
 }
@@ -67,17 +67,35 @@ extern "C" void update_write_memory_pattern_gpu(uint64_t item, char * buf, size_
 
 extern "C" int verify_memory_pattern_gpu(uint64_t item, char * buffer, size_t bytes, int rand_seed, int pretendRank, ior_dataPacketType_e dataPacketType){
   int errors = 0;
-  size_t blocks = (bytes+2047)/2048;
+  int result = -1;
+  int *derror_found = NULL;
   size_t threads = 256;
-  int * derror_found;
-  gpu_runtime_malloc((void**) & derror_found, sizeof(int));
-  gpu_runtime_memcpy(derror_found, & errors, sizeof(int), GPU_MEMCPY_HOST_TO_DEVICE);
-  if(dataPacketType == DATA_TIMESTAMP){
-    cu_verify_memory_timestamp<<<blocks, threads>>>(item, (uint64_t*) buffer, bytes/sizeof(uint64_t), rand_seed, ((uint64_t) pretendRank) << 32, derror_found);
-  }else if(dataPacketType == DATA_INCOMPRESSIBLE){
+  size_t words = bytes / sizeof(uint64_t);
+  size_t blocks = words / threads + (words % threads != 0);
 
-  }
-  gpu_runtime_memcpy(& errors, derror_found, sizeof(int), GPU_MEMCPY_DEVICE_TO_HOST);
-  gpu_runtime_free(derror_found);
-  return errors;
+  if (dataPacketType != DATA_TIMESTAMP || bytes % sizeof(uint64_t) != 0)
+    return -1;
+  if (bytes == 0)
+    return 0;
+  if (!gpu_runtime_ok(gpu_runtime_malloc((void **)&derror_found, sizeof(int))))
+    return -1;
+  if (!gpu_runtime_ok(gpu_runtime_memcpy(derror_found, &errors, sizeof(int),
+                                       GPU_MEMCPY_HOST_TO_DEVICE)))
+    goto out;
+
+  cu_verify_memory_timestamp<<<blocks, threads>>>(
+      item, (uint64_t *)buffer, words, rand_seed,
+      ((uint64_t)pretendRank) << 32, derror_found);
+  if (hipGetLastError() != hipSuccess)
+    goto out;
+  if (hipDeviceSynchronize() != hipSuccess)
+    goto out;
+  if (!gpu_runtime_ok(gpu_runtime_memcpy(&errors, derror_found, sizeof(int),
+                                       GPU_MEMCPY_DEVICE_TO_HOST)))
+    goto out;
+  result = errors;
+out:
+  if (!gpu_runtime_ok(gpu_runtime_free(derror_found)))
+    result = -1;
+  return result;
 }

--- a/src/utilities-gpu.cu
+++ b/src/utilities-gpu.cu
@@ -61,8 +61,6 @@ extern "C" void generate_memory_pattern_gpu(char * buf, size_t bytes, int rand_s
 
 extern "C" void update_write_memory_pattern_gpu(uint64_t item, char * buf, size_t bytes, int rand_seed, int rank, ior_dataPacketType_e dataPacketType){
   // nothing to do for dataPacketType == DATA_TIMESTAMP, i.e., won't be called for this parameter
-  size_t blocks = (bytes+2047)/2048;
-  size_t threads = 256;
 }
 
 extern "C" int verify_memory_pattern_gpu(uint64_t item, char * buffer, size_t bytes, int rand_seed, int pretendRank, ior_dataPacketType_e dataPacketType){

--- a/src/utilities-gpu.cu
+++ b/src/utilities-gpu.cu
@@ -36,7 +36,7 @@ void cu_verify_memory_timestamp(uint64_t item, uint64_t * buf, size_t length, in
   if(pos < length){
     int correct = buf[pos] == (pretendRank | rand_seed + pos);
     if(! correct){
-      *errors = 1; // it isn't thread safe but one error reported is enough
+      atomicExch(errors, 1);
     }
   }
 }
@@ -67,17 +67,35 @@ extern "C" void update_write_memory_pattern_gpu(uint64_t item, char * buf, size_
 
 extern "C" int verify_memory_pattern_gpu(uint64_t item, char * buffer, size_t bytes, int rand_seed, int pretendRank, ior_dataPacketType_e dataPacketType){
   int errors = 0;
-  size_t blocks = (bytes+2047)/2048;
-  size_t threads = 256;  
-  int * derror_found;
-  gpu_runtime_malloc((void**) & derror_found, sizeof(int));
-  gpu_runtime_memcpy(derror_found, & errors, sizeof(int), GPU_MEMCPY_HOST_TO_DEVICE);
-  if(dataPacketType == DATA_TIMESTAMP){
-    cu_verify_memory_timestamp<<<blocks, threads>>>(item, (uint64_t*) buffer, bytes/sizeof(uint64_t), rand_seed, ((uint64_t) pretendRank) << 32, derror_found);
-  }else if(dataPacketType == DATA_INCOMPRESSIBLE){
-    
-  }
-  gpu_runtime_memcpy(& errors, derror_found, sizeof(int), GPU_MEMCPY_DEVICE_TO_HOST);
-  gpu_runtime_free(derror_found);
-  return errors;
+  int result = -1;
+  int *derror_found = NULL;
+  size_t threads = 256;
+  size_t words = bytes / sizeof(uint64_t);
+  size_t blocks = words / threads + (words % threads != 0);
+
+  if (dataPacketType != DATA_TIMESTAMP || bytes % sizeof(uint64_t) != 0)
+    return -1;
+  if (bytes == 0)
+    return 0;
+  if (!gpu_runtime_ok(gpu_runtime_malloc((void **)&derror_found, sizeof(int))))
+    return -1;
+  if (!gpu_runtime_ok(gpu_runtime_memcpy(derror_found, &errors, sizeof(int),
+                                       GPU_MEMCPY_HOST_TO_DEVICE)))
+    goto out;
+
+  cu_verify_memory_timestamp<<<blocks, threads>>>(
+      item, (uint64_t *)buffer, words, rand_seed,
+      ((uint64_t)pretendRank) << 32, derror_found);
+  if (cudaGetLastError() != cudaSuccess)
+    goto out;
+  if (cudaDeviceSynchronize() != cudaSuccess)
+    goto out;
+  if (!gpu_runtime_ok(gpu_runtime_memcpy(&errors, derror_found, sizeof(int),
+                                       GPU_MEMCPY_DEVICE_TO_HOST)))
+    goto out;
+  result = errors;
+out:
+  if (!gpu_runtime_ok(gpu_runtime_free(derror_found)))
+    result = -1;
+  return result;
 }

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -212,6 +212,10 @@ int verify_memory_pattern(uint64_t item, char * buffer, size_t bytes, int rand_s
 #ifdef HAVE_GPU
   if(type == IOR_MEMORY_TYPE_GPU_DEVICE_ONLY || type == IOR_MEMORY_TYPE_GPU_MANAGED_CHECK_GPU){
     error = verify_memory_pattern_gpu(item, buffer, bytes, rand_seed, pretendRank, dataPacketType);
+    if (error < 0) {
+      ERR("GPU verification could not run: runtime failure or unsupported packet type/size");
+      return 1;
+    }
     return error;
   }
 #endif

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -17,14 +17,9 @@
 #endif
 
 #ifdef HAVE_GETCPU_SYSCALL
-#  define _GNU_SOURCE
 #  include <unistd.h>
 #  include <sys/syscall.h>
 #endif
-
-#ifdef __linux__
-#  define _GNU_SOURCE            /* Needed for O_DIRECT in fcntl */
-#endif                           /* __linux__ */
 
 #include <stdarg.h>
 #include <stdio.h>


### PR DESCRIPTION
Follow-up fixes for the GPU Direct Storage code merged in #539 and #540. A post-merge review found a configure-time defect, a few smaller correctness issues, and one build failure that shows up with recent CUDA headers.

### Problem

- The hipFile configure probe compiles and links with only the hipFile flags. But hipfile.h includes hip/hip_runtime_api.h, and libhipfile.so can depend on libamdhip64.so without an embedded RUNPATH. With HIP installed under a separate prefix, configure rejects a working hipFile installation before the build even starts.
- cuFile reads and writes can fail with -1 and errno set (filesystem errors), separate from negative CUfileOpError_t values. The cuFile decoder treated every negative return as an operation error, so the real POSIX cause was lost. The hipFile backend already handled this correctly.
- Neither backend ever closed its storage driver. POSIX_Finalize was empty, and the cuFile backend's lazy-open flag was never reset. The HIP side relied on implicit initialization during handle registration and had no shutdown path at all.
- GPU verification could report success without checking data. Allocation, copies, and kernel launches were unchecked, so a runtime failure left the error counter at zero. Verification modes other than timestamps (including incompressible) verified nothing but still returned success.
- On short GPU transfers the retry loop advanced both the pointer and the buffer offset, so the next call read or wrote at base + 2*r instead of base + r.
- Compiling src/gpu_io_cufile.c against CUDA 13.3 fails: cufile.h uses loff_t in its callback structs, which glibc only exposes with _GNU_SOURCE. IOR does not enable system extensions, so the cuFile backend does not build on current toolkits.

### Change

Seven commits, one per fix:

- configure: preserve HIP flags in hipFile probes -- the hipFile probe now carries the HIP include flags, library paths, and the detected runtime library in its temporary environment, restoring all three caller variables afterwards. This resolves transitive header and link dependencies for separate HIP and hipFile prefixes.
- gpu: preserve errno for cuFile transfer failures -- the transfer decoder now distinguishes -1 with errno from negative operation errors, matching the hipFile backend.
- gpu: close storage drivers after final POSIX instance -- both backends own a lazy-opened driver session and release it when the last POSIX instance finalizes (instance count, since ior dispatches initialize/finalize per test). A failed close is reported as a fatal error rather than ignored.
- gpu: fail explicitly when verification cannot run -- both verifiers check allocation, copies, launch, execution, and cleanup; the timestamp kernel reports mismatches atomically; unsupported packet types and non-word-sized buffers are rejected instead of silently passing; the common dispatch aborts when verification cannot run rather than letting a failure look like a clean result.
- posix: keep the GPU transfer buffer base fixed -- GPU paths pass the original buffer base and advance only the buffer offset after short transfers, so completed bytes no longer displace the next transfer twice. Syscall paths are unchanged.
- configure: enable system extensions for large-file types -- AC_USE_SYSTEM_EXTENSIONS defines _GNU_SOURCE project-wide, fixing the cufile.h loff_t build failure and making the local feature defines in three files redundant (removed).
- gpu: drop unused variables in the pattern update stub.

### Testing

Built on Rocky Linux 10 with ROCm 7.14 and CUDA 13.3:

| configuration | result |
|---|---|
| CPU-only (--without-cuda --without-hip, backend none) | pass |
| HIP runtime + hipFile backend | pass |
| CUDA runtime + cuFile backend | pass |
